### PR TITLE
move useFieldArray hook to ManifestForm, pass append method as props,…

### DIFF
--- a/client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -13,6 +13,7 @@ interface State {
 class ErrorBoundary extends Component<Props, State> {
   public state: State = {
     hasError: false,
+    error: undefined,
   };
 
   public static getDerivedStateFromError(error: Error): State {

--- a/client/src/components/ManifestForm/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm/ManifestForm.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react';
-import { Container, Button, Form, Row, Col } from 'react-bootstrap';
+import { Button, Form, Row, Col } from 'react-bootstrap';
 import HtCard from 'components/HtCard';
-import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
+import {
+  useForm,
+  FormProvider,
+  SubmitHandler,
+  useFieldArray,
+} from 'react-hook-form';
 import { Handler, Manifest } from 'types';
 import HandlerForm from '../HandlerForm';
 import { HandlerType } from 'types/Handler/Handler';
@@ -17,6 +22,7 @@ function ManifestForm() {
   const methods = useForm<Manifest>({ resolver: yupResolver(ManifestSchema) });
 
   const {
+    control,
     formState: { errors },
   } = methods;
 
@@ -27,7 +33,13 @@ function ManifestForm() {
   const toggleTranSearchShow = () => setTransFormShow(!transFormShow);
 
   const transporters: [Handler] = methods.getValues('transporters');
-  console.log(transporters);
+
+  const { append } = useFieldArray({
+    control,
+    name: 'transporters',
+  });
+
+  console.log('append: ', append);
 
   return (
     <>
@@ -77,6 +89,7 @@ function ManifestForm() {
         <TransporterSearch
           handleClose={toggleTranSearchShow}
           show={transFormShow}
+          tranAppend={append}
         />
       </FormProvider>
     </>

--- a/client/src/components/ManifestForm/Transporter/TransporterSearch.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterSearch.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import TransporterSearchForm from './TransporterSearchForm';
 import { Modal, Row, Col } from 'react-bootstrap';
+import { UseFieldArrayAppend } from 'react-hook-form';
+import { Manifest } from 'types';
 
 interface Props {
   handleClose: () => void;
   show: boolean | undefined;
+  tranAppend: UseFieldArrayAppend<Manifest, 'transporters'>;
 }
 
-function TransporterSearch({ handleClose, show }: Props) {
+function TransporterSearch({ handleClose, show, tranAppend }: Props) {
   return (
     <Modal show={show} onHide={handleClose}>
       <Modal.Header closeButton>
@@ -24,7 +27,11 @@ function TransporterSearch({ handleClose, show }: Props) {
           </Row>
         </Col>
       </Modal.Header>
-      <TransporterSearchForm handleClose={handleClose} show={show} />
+      <TransporterSearchForm
+        handleClose={handleClose}
+        show={show}
+        tranAppend={tranAppend}
+      />
     </Modal>
   );
 }

--- a/client/src/components/ManifestForm/Transporter/TransporterSearchForm.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterSearchForm.tsx
@@ -4,15 +4,17 @@ import {
   useForm,
   useFormContext,
   SubmitHandler,
-  useFieldArray,
+  UseFieldArrayAppend,
 } from 'react-hook-form';
 import { ErrorMessage } from '@hookform/error-message';
 import api from 'services';
 import { Transporter } from 'types/Transporter/Transporter';
+import { Manifest } from 'types';
 
 interface Props {
   handleClose: () => void;
   show: boolean | undefined;
+  tranAppend: UseFieldArrayAppend<Manifest, 'transporters'>;
 }
 
 interface SearchCriteria {
@@ -26,7 +28,7 @@ interface FormValues {
   name: string;
 }
 
-function TransporterSearchForm({ handleClose, show }: Props) {
+function TransporterSearchForm({ handleClose, show, tranAppend }: Props) {
   // The Transporter is a separate form, but is used in the context of a ManifestForm
   const manifestForm = useFormContext();
 
@@ -40,14 +42,6 @@ function TransporterSearchForm({ handleClose, show }: Props) {
     watch,
     formState: { errors },
   } = useForm<FormValues>();
-
-  // Todo: this hook needs to be 'owned' by the ManifestForm and passed as a prop
-  //  to this form. That way the manifest form can do things like remove, reorder, insert, etc. Transporters.
-  //  https://legacy.react-hook-form.com/api/usefieldarray
-  const { append } = useFieldArray({
-    control: manifestForm.control,
-    name: 'transporters',
-  });
 
   /**
    This is the data that is sent to the RESTful api, it's automatically updated
@@ -85,7 +79,7 @@ function TransporterSearchForm({ handleClose, show }: Props) {
       for (let i = 0; i < tranOptions?.length; i++) {
         if (tranOptions[i].epaSiteId === data.transporter) {
           // append in run in the ManifestForm context, on the 'transporter' field
-          append(tranOptions[i]);
+          tranAppend(tranOptions[i]);
           console.log(manifestForm.getValues()); // uncomment to see how the new transporter is added to the manifest
         }
       }


### PR DESCRIPTION
## Description
This PR moves the useFieldArray hook for the manifest form transporter field up the component ladder into `ManifestForm`. The UseFieldArrayAppend method is passed as a prop to the transporter search components. 


<br/><br/>
## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->

closes #190 

<br/><br/>
## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<br/><br/>
## Other Stuff

