### PR TITLE
Fix: convert Handler to new Transporter type on manifest

### DIFF
--- a/client/src/components/ManifestForm/HandlerForm/HandlerForm.tsx
+++ b/client/src/components/ManifestForm/HandlerForm/HandlerForm.tsx
@@ -94,7 +94,7 @@ function HandlerForm({ handlerType }: Props): JSX.Element {
           <></>
         )}
       </Row>
-      <Button type="submit">{`Add ${handlerType}`}</Button>
+      {/*<Button type="submit">{`Add ${handlerType}`}</Button>*/}
     </>
   );
 }

--- a/client/src/components/ManifestForm/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm/ManifestForm.tsx
@@ -16,6 +16,7 @@ import {
   TransporterSearch,
   TransporterTable,
 } from 'components/ManifestForm/Transporter';
+import { Transporter } from '../../../types/Transporter/Transporter';
 
 function ManifestForm() {
   // methods contains all the useForm context
@@ -29,17 +30,15 @@ function ManifestForm() {
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) =>
     console.log(data);
 
-  const [transFormShow, setTransFormShow] = useState(false);
+  const [transFormShow, setTransFormShow] = useState<boolean>(false);
   const toggleTranSearchShow = () => setTransFormShow(!transFormShow);
 
-  const transporters: [Handler] = methods.getValues('transporters');
+  const transporters: [Transporter] = methods.getValues('transporters');
 
-  const { append } = useFieldArray({
+  const { append } = useFieldArray<Manifest, 'transporters'>({
     control,
     name: 'transporters',
   });
-
-  console.log('append: ', append);
 
   return (
     <>
@@ -89,6 +88,7 @@ function ManifestForm() {
         <TransporterSearch
           handleClose={toggleTranSearchShow}
           show={transFormShow}
+          currentTransporters={transporters}
           tranAppend={append}
         />
       </FormProvider>

--- a/client/src/components/ManifestForm/Transporter/TransporterSearch.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterSearch.tsx
@@ -3,14 +3,21 @@ import TransporterSearchForm from './TransporterSearchForm';
 import { Modal, Row, Col } from 'react-bootstrap';
 import { UseFieldArrayAppend } from 'react-hook-form';
 import { Manifest } from 'types';
+import { Transporter } from '../../../types/Transporter/Transporter';
 
 interface Props {
   handleClose: () => void;
   show: boolean | undefined;
+  currentTransporters?: [Transporter];
   tranAppend: UseFieldArrayAppend<Manifest, 'transporters'>;
 }
 
-function TransporterSearch({ handleClose, show, tranAppend }: Props) {
+function TransporterSearch({
+  handleClose,
+  show,
+  tranAppend,
+  currentTransporters,
+}: Props) {
   return (
     <Modal show={show} onHide={handleClose}>
       <Modal.Header closeButton>
@@ -29,8 +36,8 @@ function TransporterSearch({ handleClose, show, tranAppend }: Props) {
       </Modal.Header>
       <TransporterSearchForm
         handleClose={handleClose}
-        show={show}
         tranAppend={tranAppend}
+        currentTransporters={currentTransporters}
       />
     </Modal>
   );

--- a/client/src/components/ManifestForm/Transporter/TransporterSearchForm.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterSearchForm.tsx
@@ -9,11 +9,11 @@ import {
 import { ErrorMessage } from '@hookform/error-message';
 import api from 'services';
 import { Transporter } from 'types/Transporter/Transporter';
-import { Manifest } from 'types';
+import { Handler, Manifest } from 'types';
 
 interface Props {
   handleClose: () => void;
-  show: boolean | undefined;
+  currentTransporters?: [Transporter];
   tranAppend: UseFieldArrayAppend<Manifest, 'transporters'>;
 }
 
@@ -28,11 +28,15 @@ interface FormValues {
   name: string;
 }
 
-function TransporterSearchForm({ handleClose, show, tranAppend }: Props) {
+function TransporterSearchForm({
+  handleClose,
+  tranAppend,
+  currentTransporters,
+}: Props) {
   // The Transporter is a separate form, but is used in the context of a ManifestForm
   const manifestForm = useFormContext();
 
-  const [tranOptions, setTranOptions] = useState<[Transporter] | undefined>(
+  const [tranOptions, setTranOptions] = useState<[Handler] | undefined>(
     undefined
   );
 
@@ -67,7 +71,7 @@ function TransporterSearchForm({ handleClose, show, tranAppend }: Props) {
       }
     }
 
-    fetchOptions().then((trans) => setTranOptions(trans));
+    fetchOptions().then((trans: [Handler]) => setTranOptions(trans));
   }, [watch('epaId'), watch('name')]);
 
   /**Use the value (string) set in the Form.Select to look up
@@ -79,7 +83,15 @@ function TransporterSearchForm({ handleClose, show, tranAppend }: Props) {
       for (let i = 0; i < tranOptions?.length; i++) {
         if (tranOptions[i].epaSiteId === data.transporter) {
           // append in run in the ManifestForm context, on the 'transporter' field
-          tranAppend(tranOptions[i]);
+          // const numberOfTransporter = currentTransporters?.length;
+          const numberOfTransporter = currentTransporters
+            ? currentTransporters.length
+            : 0;
+          const newTransporter: Transporter = {
+            order: numberOfTransporter + 1,
+            ...tranOptions[i],
+          };
+          tranAppend(newTransporter);
           console.log(manifestForm.getValues()); // uncomment to see how the new transporter is added to the manifest
         }
       }

--- a/client/src/components/ManifestForm/Transporter/TransporterTable.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable.tsx
@@ -27,7 +27,7 @@ function TransporterTable({ transporters }: Props) {
         {transporters.map((transporter, index) => {
           return (
             <tr key={index}>
-              <td>{index + 1}</td>
+              <td>{transporter.order}</td>
               <td>{transporter.epaSiteId}</td>
               <td>{transporter.name}</td>
               <td>{transporter.canEsign ? 'yes' : 'no'}</td>

--- a/client/src/types/Manifest/Manifest.ts
+++ b/client/src/types/Manifest/Manifest.ts
@@ -5,6 +5,7 @@ import { Handler, Locality } from '../Handler/Handler';
 import { CorrectionInfo, CorrectionRequest } from './Correction';
 import { RejectionInfo } from './Rejection';
 import { Waste } from './Waste';
+import { Transporter } from '../Transporter/Transporter';
 
 interface Manifest {
   createdDate?: string;
@@ -21,7 +22,7 @@ interface Manifest {
   certifiedDate: string;
   certifiedBy: Signer;
   generator: Handler;
-  transporters: [Handler]; // todo: convert to 'Transporter' type definition
+  transporters: [Transporter];
   designatedFacility: Handler;
   broker?: Handler;
   wastes: Waste[];

--- a/client/src/types/Transporter/Transporter.ts
+++ b/client/src/types/Transporter/Transporter.ts
@@ -2,5 +2,5 @@ import { Handler } from 'types';
 
 export interface Transporter extends Handler {
   order: number;
-  manifest: number;
+  manifest?: number;
 }


### PR DESCRIPTION
## Description

Transporters added to the object created with the manifest form is a Transporter type, not Handler. When a transporter is added via the TransporterSearchForm, a new transporter is created by adding  `order` to the existing `Handler` object and appending to the array of tranporters. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->

closes #188 


## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

