### PR TITLE
194 transporter remove action

### DIFF
--- a/client/src/components/ManifestForm/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm/ManifestForm.tsx
@@ -7,7 +7,7 @@ import {
   SubmitHandler,
   useFieldArray,
 } from 'react-hook-form';
-import { Handler, Manifest } from 'types';
+import { Manifest } from 'types';
 import HandlerForm from '../HandlerForm';
 import { HandlerType } from 'types/Handler/Handler';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -16,7 +16,7 @@ import {
   TransporterSearch,
   TransporterTable,
 } from 'components/ManifestForm/Transporter';
-import { Transporter } from '../../../types/Transporter/Transporter';
+import { Transporter } from 'types/Transporter/Transporter';
 import WasteLine from '../WasteLine';
 import Tsdf from '../Tsdf';
 
@@ -34,12 +34,12 @@ function ManifestForm() {
   const [transFormShow, setTransFormShow] = useState<boolean>(false);
   const toggleTranSearchShow = () => setTransFormShow(!transFormShow);
   const transporters: [Transporter] = methods.getValues('transporters');
-  const { append } = useFieldArray<Manifest, 'transporters'>({
+  const { append, remove } = useFieldArray<Manifest, 'transporters'>({
     control,
     name: 'transporters',
   });
 
-  // Wasteline controls
+  // WasteLine controls
   const [wlFormShow, setWlFormShow] = useState<boolean>(false);
   const toggleWlFormShow = () => setWlFormShow(!wlFormShow);
 
@@ -76,7 +76,10 @@ function ManifestForm() {
             <HtCard.Header title="Transporters" />
             <HtCard.Body className="bg-light rounded py-4">
               {/* List transporters */}
-              <TransporterTable transporters={transporters} />
+              <TransporterTable
+                transporters={transporters}
+                removeTransporter={remove}
+              />
               <Row className="d-flex justify-content-center px-5">
                 <Col className="text-center">
                   <Button variant="success" onClick={toggleTranSearchShow}>
@@ -121,7 +124,7 @@ function ManifestForm() {
           handleClose={toggleTranSearchShow}
           show={transFormShow}
           currentTransporters={transporters}
-          tranAppend={append}
+          appendTransporter={append}
         />
         <WasteLine handleClose={toggleWlFormShow} show={wlFormShow} />
         <Tsdf handleClose={toggleTsdfFormShow} show={tsdfFormShow} />

--- a/client/src/components/ManifestForm/Transporter/TransporterRowActions.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterRowActions.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
+import { UseFieldArrayRemove } from 'react-hook-form';
 
-function TransporterRowActions() {
+interface Props {
+  order: number;
+  removeTransporter: UseFieldArrayRemove;
+}
+
+function TransporterRowActions({ order, removeTransporter }: Props) {
   return (
     <div className="d-flex justify-content-between mx-0">
       <Button
@@ -18,7 +24,9 @@ function TransporterRowActions() {
       </Button>
       <Button
         className="m-0 p-0 bg-transparent border-0"
-        onClick={() => console.log('hello')}
+        onClick={() => {
+          removeTransporter(order);
+        }}
       >
         <i className="text-danger fas fa-times-circle fa-lg"></i>
       </Button>

--- a/client/src/components/ManifestForm/Transporter/TransporterSearch.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterSearch.tsx
@@ -9,13 +9,13 @@ interface Props {
   handleClose: () => void;
   show: boolean | undefined;
   currentTransporters?: [Transporter];
-  tranAppend: UseFieldArrayAppend<Manifest, 'transporters'>;
+  appendTransporter: UseFieldArrayAppend<Manifest, 'transporters'>;
 }
 
 function TransporterSearch({
   handleClose,
   show,
-  tranAppend,
+  appendTransporter,
   currentTransporters,
 }: Props) {
   return (
@@ -36,7 +36,7 @@ function TransporterSearch({
       </Modal.Header>
       <TransporterSearchForm
         handleClose={handleClose}
-        tranAppend={tranAppend}
+        tranAppend={appendTransporter}
         currentTransporters={currentTransporters}
       />
     </Modal>

--- a/client/src/components/ManifestForm/Transporter/TransporterSearchForm.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterSearchForm.tsx
@@ -92,7 +92,7 @@ function TransporterSearchForm({
             ...tranOptions[i],
           };
           tranAppend(newTransporter);
-          console.log(manifestForm.getValues()); // uncomment to see how the new transporter is added to the manifest
+          // console.log(manifestForm.getValues()); // uncomment to see how the new transporter is added to the manifest
         }
       }
     }

--- a/client/src/components/ManifestForm/Transporter/TransporterTable.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable.tsx
@@ -1,17 +1,35 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Table } from 'react-bootstrap';
 import { Handler } from 'types';
 import TransporterRowActions from './TransporterRowActions';
+import { UseFieldArrayRemove } from 'react-hook-form';
 
 interface Props {
   transporters?: [Handler];
+  removeTransporter: UseFieldArrayRemove;
 }
 
-function TransporterTable({ transporters }: Props) {
-  if (!transporters) {
+function TransporterTable({ transporters, removeTransporter }: Props) {
+  // useEffect(() => {
+  //   if (transporters) {
+  //     for (let i = 0; i < transporters?.length; i++) {
+  //       transporters[i].order = i + 1;
+  //       console.log(transporters[i]);
+  //     }
+  //   }
+  // }, [transporters]);
+
+  if (!transporters || transporters.length < 1) {
     return <></>;
   }
+  if (transporters) {
+    console.log(transporters);
+    for (let i = 0; i < transporters?.length; i++) {
+      transporters[i].order = i + 1;
+    }
+  }
 
+  console.log(transporters);
   return (
     <Table striped>
       <thead>
@@ -32,7 +50,10 @@ function TransporterTable({ transporters }: Props) {
               <td>{transporter.name}</td>
               <td>{transporter.canEsign ? 'yes' : 'no'}</td>
               <td>
-                <TransporterRowActions />
+                <TransporterRowActions
+                  removeTransporter={removeTransporter}
+                  order={index}
+                />
               </td>
             </tr>
           );

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
@@ -34,4 +34,4 @@ function TransporterRowActions({ order, removeTransporter }: Props) {
   );
 }
 
-export default TransporterRowActions;
+export { TransporterRowActions };

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Table } from 'react-bootstrap';
 import { Handler } from 'types';
-import TransporterRowActions from './TransporterRowActions';
+import { TransporterRowActions } from './TransporterRowActions';
 import { UseFieldArrayRemove } from 'react-hook-form';
 
 interface Props {
@@ -63,4 +63,4 @@ function TransporterTable({ transporters, removeTransporter }: Props) {
   );
 }
 
-export default TransporterTable;
+export { TransporterTable };

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/index.ts
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/index.ts
@@ -1,0 +1,4 @@
+import { TransporterTable } from './TransporterTable';
+import { TransporterRowActions } from './TransporterRowActions';
+
+export { TransporterTable, TransporterRowActions };

--- a/client/src/components/ManifestForm/Transporter/index.ts
+++ b/client/src/components/ManifestForm/Transporter/index.ts
@@ -1,4 +1,5 @@
 import TransporterSearch from './TransporterSearch';
-import TransporterTable from './TransporterTable';
+// import TransporterTable from './TransporterTable/TransporterTable';
+import { TransporterTable } from './TransporterTable';
 
 export { TransporterSearch, TransporterTable };


### PR DESCRIPTION
## Description

This PR adds the ability to remove transporters from the manifest, the manifest automatically modifies the order field of each transporter when a transporter from the array is removed (a row is deleted).  

I don't have time for to write up a test, but I believe a couple tests for this component would be worth the effort. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->


closes #194

## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

