### PR TITLE
add HtSpinner, refactor out of HtCard, initial HtError

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
 import { Container } from 'react-bootstrap';
 import PrivateRoute from 'components/PrivateRoute';
@@ -13,6 +13,7 @@ import { useAppSelector } from 'redux/hooks';
 import Manifest from 'features/manifest';
 import ErrorBoundary from 'components/ErrorBoundary';
 import { RootState } from './redux/store';
+import HtError from './components/HtError';
 
 function App(): ReactElement {
   const { user } = useAppSelector((state: RootState) => state.user);
@@ -59,7 +60,7 @@ function App(): ReactElement {
               />
               <Route path="/login" element={<Login />} />
               <Route path="/about" element={<About />} />
-              <Route path="*" element={<Navigate to="/" />} />
+              <Route path="*" element={<HtError httpError={404} />} />
             </Routes>
           </ErrorBoundary>
         </Container>

--- a/client/src/components/HtCard/HtCard.tsx
+++ b/client/src/components/HtCard/HtCard.tsx
@@ -1,20 +1,19 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { Card } from 'react-bootstrap';
 import ErrorBoundary from '../ErrorBoundary';
+import HtSpinner from '../HtSpinner';
 
 interface Props {
   id?: string;
-  children?: any;
+  children?: ReactNode;
   className?: string;
 }
 
-interface HeaderProps {
-  id?: string;
+interface HeaderProps extends Props {
   title?: string;
-  children?: any;
 }
 
-interface SpinnerProps {
+interface SpinnerProps extends Props {
   message?: string;
 }
 
@@ -29,10 +28,10 @@ interface SpinnerProps {
  *   <HtCard.Footer>submit button here<HtCard.Footer>
  * </HtCard>
  */
-function HtCard(props: Props): ReactElement {
+function HtCard({ id, children, className }: Props): ReactElement {
   return (
-    <div id={props.id} className="my-3 shadow-lg bg-light rounded">
-      {props.children}
+    <div id={id} className={`my-3 shadow-lg bg-light rounded ${className}`}>
+      {children}
     </div>
   );
 }
@@ -46,12 +45,16 @@ function HtCard(props: Props): ReactElement {
  *   <HtCard.Header title="Card Title!">{top right dropdown button}<HtCard.Header>
  * </HtCard>
  */
-HtCard.Header = function (props: HeaderProps): ReactElement {
+HtCard.Header = function ({
+  children,
+  className,
+  title,
+}: HeaderProps): ReactElement {
   return (
-    <Card.Header className="bg-primary text-light rounded-top">
+    <Card.Header className={`bg-primary text-light rounded-top ${className}`}>
       <div className="d-flex justify-content-between p-1 px-2 py-1">
-        <div className="fw-bold h5">{props.title}</div>
-        <div>{props.children}</div>
+        <div className="fw-bold h5">{title}</div>
+        <div>{children}</div>
       </div>
     </Card.Header>
   );
@@ -68,7 +71,7 @@ HtCard.Header = function (props: HeaderProps): ReactElement {
  */
 HtCard.Footer = function (props: Props): ReactElement {
   return (
-    <Card.Footer className="bg-gray">
+    <Card.Footer className={`bg-gray ${props.className}`}>
       <div className="d-flex justify-content-start gap-2">{props.children}</div>
     </Card.Footer>
   );
@@ -84,9 +87,9 @@ HtCard.Footer = function (props: Props): ReactElement {
  * </HtCard>
  */
 HtCard.Body = function (props: Props): ReactElement {
-  if (typeof props.className === undefined) {
-    props.className = '';
-  }
+  // if (typeof props.className === undefined) {
+  //   props.className = '';
+  // }
   return (
     <Card.Body className={props.className ? `${props.className}` : ''}>
       <ErrorBoundary>
@@ -99,21 +102,15 @@ HtCard.Body = function (props: Props): ReactElement {
 /**
  * Card spinner to use while asynchronous promise is in pending state
  * @param {{message: String}} message string to render next to spinner
+ * @param {{classname: String}} string class attributes to pass
  * @constructor
  * @example
  * <HtCard.Body>
  *   <HtCard.Spinner message="loading..."/>
  * </HtCard.Body>
  */
-HtCard.Spinner = function ({ message }: SpinnerProps): ReactElement {
-  return (
-    <>
-      <h4 className="d-flex justify-content-center text-muted bg-transparent p-1 py-3">
-        <i className="fa-solid fa-spin fa-circle-notch"></i>
-        &nbsp;&nbsp;{message}
-      </h4>
-    </>
-  );
+HtCard.Spinner = function ({ message, className }: SpinnerProps): ReactElement {
+  return <HtSpinner message={message} className={className} />;
 };
 
 export default HtCard;

--- a/client/src/components/HtError/HtError.tsx
+++ b/client/src/components/HtError/HtError.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Alert, Button, Col, Container, Row } from 'react-bootstrap';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+interface Props {
+  httpError?: 404 | 500;
+}
+
+function HtError({ httpError }: Props) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const errorMsg = location.state;
+  console.log('this is the error', errorMsg);
+
+  return (
+    <Container fluid className="p-5">
+      <Row className="py-4 d-flex justify-content-center">
+        <Col className="col-lg-8 col-md-10">
+          <Row className="d-flex justify-content-center text-center">
+            {httpError ? (
+              <h1 className="text-danger display-2 fw-bold">{`${httpError}`}</h1>
+            ) : (
+              <i className="text-danger h1 fas fa-bug"></i>
+            )}
+          </Row>
+          <Row className="d-flex justify-content-center">
+            <h4 className="d-flex justify-content-center">
+              Something went wrong
+            </h4>
+          </Row>
+          {errorMsg ? (
+            <Row className="d-flex justify-content-center pt-4">
+              <Alert key="danger" variant="danger">
+                {`${errorMsg}`}
+              </Alert>
+            </Row>
+          ) : (
+            ''
+          )}
+        </Col>
+      </Row>
+      <Row>
+        <div className="py-4 d-flex justify-content-end">
+          <Button className="mx-2" onClick={() => navigate(-1)}>
+            Go Back
+          </Button>
+          <Button className="mx-2" onClick={() => navigate('/')}>
+            Go Home
+          </Button>
+        </div>
+      </Row>
+    </Container>
+  );
+}
+
+export default HtError;

--- a/client/src/components/HtError/index.ts
+++ b/client/src/components/HtError/index.ts
@@ -1,0 +1,3 @@
+import HtError from './HtError';
+
+export default HtError;

--- a/client/src/components/HtSpinner/HtSpinner.tsx
+++ b/client/src/components/HtSpinner/HtSpinner.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+
+interface SpinnerProps {
+  message?: string;
+  className?: string;
+}
+
+function HtSpinner({ message, className }: SpinnerProps): ReactElement {
+  return (
+    <>
+      <p
+        className={`h4 d-flex justify-content-center text-muted bg-transparent p-1 py-3 ${className}`}
+      >
+        <i className="fa-solid display-2 fa-spin fa-circle-notch"></i>
+        &nbsp;&nbsp;{message}
+      </p>
+    </>
+  );
+}
+
+export default HtSpinner;

--- a/client/src/components/HtSpinner/index.ts
+++ b/client/src/components/HtSpinner/index.ts
@@ -1,0 +1,3 @@
+import HtSpinner from './HtSpinner';
+
+export default HtSpinner;

--- a/client/src/features/manifest/ManifestDetails/ManifestDetails.tsx
+++ b/client/src/features/manifest/ManifestDetails/ManifestDetails.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import api from 'services';
 import { Manifest } from 'types';
 import { Col, Row } from 'react-bootstrap';
 import HtCard from 'components/HtCard';
+import HtSpinner from '../../../components/HtSpinner';
 
 /**
  * This React component displays an existing hazardous waste manifest.
@@ -14,12 +15,11 @@ import HtCard from 'components/HtCard';
  */
 function ManifestDetails(): ReactElement {
   let { mtn } = useParams();
-  const navigate = useNavigate();
   const [manifestData, setManifestData] = useState<Manifest | undefined>(
     undefined
   );
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(false);
+  const [_error, setError] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -32,8 +32,7 @@ function ManifestDetails(): ReactElement {
       .catch((error) => {
         // Todo: error handling if, e.g., mtn does not exist.
         setError(error);
-        setLoading(false);
-        navigate('/');
+        // setLoading(false);
       });
   }, [mtn]);
 
@@ -42,7 +41,9 @@ function ManifestDetails(): ReactElement {
   const tsdPhone = manifestData?.designatedFacility.contact.phone.number;
   const tsdEmerPhone = manifestData?.designatedFacility.emergencyPhone.number;
 
-  return manifestData ? (
+  return loading ? (
+    <HtSpinner />
+  ) : manifestData ? (
     <>
       <h2 className="fw-bold">{manifestData.manifestTrackingNumber}</h2>
       <HtCard>


### PR DESCRIPTION
## Description

This PR adds an HtError component, all unknown routes are sent to it. Also explored using react-error-boundary but did not like the need to reset the error state via all methods to navigate from the error page. May look again at this again in the future.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->




## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

