### PR TITLE
initial waste line table display

### DIFF
--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -1,4 +1,5 @@
 import AdditionalInfoForm from 'components/ManifestForm/AdditionalInfo';
+import { WasteLineTable } from 'components/ManifestForm/WasteLine/WasteLineTable/WasteLineTable';
 import React, { useState } from 'react';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 import HtCard from 'components/HtCard';
@@ -35,8 +36,7 @@ function ManifestForm() {
     // formState: { errors },
   } = methods;
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
-    console.log('manifest onSubmit');
-    console.log(data);
+    console.log('manifest onSubmit: ', data);
   };
 
   // Transporter controls
@@ -88,7 +88,7 @@ function ManifestForm() {
           </HtCard>
           <HtCard id="transporter-form-card">
             <HtCard.Header title="Transporters" />
-            <HtCard.Body className="py-4">
+            <HtCard.Body className="pb-4">
               {/* List transporters */}
               <TransporterTable
                 transporters={transporters}
@@ -105,8 +105,10 @@ function ManifestForm() {
           </HtCard>
           <HtCard id="waste-form-card">
             <HtCard.Header title="Waste" />
-            <HtCard.Body className="py-4">
-              <Row className="d-flex justify-content-center px-5">
+            <HtCard.Body className="pb-4">
+              <Row className="d-flex justify-content-center px-3">
+                {/* Table Showing current Waste Lines included on the manifest */}
+                <WasteLineTable wastes={wastes} />
                 <Col className="text-center">
                   <Button variant="success" onClick={toggleWlFormShow}>
                     Add Waste
@@ -118,7 +120,7 @@ function ManifestForm() {
           <HtCard id="tsdf-form-card">
             {/* Where The Tsdf information is added and displayed */}
             <HtCard.Header title="Designated Facility" />
-            <HtCard.Body className="py-4">
+            <HtCard.Body className="pb-4">
               <Row className="d-flex justify-content-center px-5">
                 <Col className="text-center">
                   <Button variant="success" onClick={toggleTsdfFormShow}>
@@ -133,7 +135,7 @@ function ManifestForm() {
             <HtCard.Header>
               <h6>Special Handling Instructions and Additional info</h6>
             </HtCard.Header>
-            <HtCard.Body className="px-4">
+            <HtCard.Body className="px-3">
               <AdditionalInfoForm />
             </HtCard.Body>
           </HtCard>

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
@@ -4,21 +4,15 @@ import { Handler } from 'types';
 import { TransporterRowActions } from './TransporterRowActions';
 import { UseFieldArrayRemove } from 'react-hook-form';
 
-interface Props {
+interface TransporterTableProps {
   transporters?: Array<Handler>;
   removeTransporter: UseFieldArrayRemove;
 }
 
-function TransporterTable({ transporters, removeTransporter }: Props) {
-  // useEffect(() => {
-  //   if (transporters) {
-  //     for (let i = 0; i < transporters?.length; i++) {
-  //       transporters[i].order = i + 1;
-  //       console.log(transporters[i]);
-  //     }
-  //   }
-  // }, [transporters]);
-
+function TransporterTable({
+  transporters,
+  removeTransporter,
+}: TransporterTableProps) {
   if (!transporters || transporters.length < 1) {
     return <></>;
   }

--- a/client/src/components/ManifestForm/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/ManifestForm/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Table } from 'react-bootstrap';
+import { WasteLine } from 'types/WasteLine';
+
+interface WasteLineTableProps {
+  wastes: Array<WasteLine>;
+}
+
+export function WasteLineTable({ wastes }: WasteLineTableProps) {
+  if (!wastes || wastes.length < 1) {
+    return <></>;
+  }
+  if (wastes) {
+    for (let i = 0; i < wastes?.length; i++) {
+      wastes[i].lineNumber = i + 1;
+    }
+  }
+  return (
+    <Table striped>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>U.S. DOT Description</th>
+          <th>Containers</th>
+          <th>Type</th>
+          <th>Codes</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {wastes.map((wasteLine, index) => {
+          return (
+            <tr key={index}>
+              <td>{wasteLine.lineNumber}</td>
+              <td>{wasteLine.wasteDescription}</td>
+              <td>{wasteLine.quantity?.containerNumber}</td>
+              <td>{String(wasteLine.quantity?.containerType)}</td>
+              <td>
+                <small>
+                  {wasteLine.hazardousWaste?.federalWasteCodes?.map(
+                    (code, index) => {
+                      // ToDo: fix how hazardous waste codes are appended to wasteline
+                      // @ts-ignore
+                      return `${String(code.value)} ${
+                        index + 1 ===
+                        wasteLine.hazardousWaste?.federalWasteCodes?.length
+                          ? ' '
+                          : ', '
+                      }`;
+                    }
+                  )}
+                </small>
+              </td>
+              <td>
+                <p>ToDo</p>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}

--- a/client/src/components/ManifestForm/WasteLine/WasteLineTable/index.ts
+++ b/client/src/components/ManifestForm/WasteLine/WasteLineTable/index.ts
@@ -1,0 +1,3 @@
+import { WasteLineTable } from './WasteLineTable';
+
+export { WasteLineTable };


### PR DESCRIPTION
## Description

This PR adds a rudimentary display to shows WasteLine objects attached to a given manifest. It should be reusable for viewing and editing manifest waste lines.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->

closes #217 


## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

