### PR TITLE
202 transporter row action swap order

### DIFF
--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -92,7 +92,7 @@ function ManifestForm() {
               {/* List transporters */}
               <TransporterTable
                 transporters={transporters}
-                removeTransporter={tranArrayMethods.remove}
+                arrayFieldMethods={tranArrayMethods}
               />
               <Row className="d-flex justify-content-center px-5">
                 <Col className="text-center">

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.spec.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TransporterRowActions } from './TransporterRowActions';
+
+afterEach(() => {
+  cleanup();
+  jest.resetAllMocks();
+});
+
+describe('TransporterRowActions', () => {
+  test('renders disabled buttons', () => {
+    const { debug } = render(
+      <TransporterRowActions
+        index={0}
+        length={1}
+        removeTransporter={() => console.log('remove')}
+        swapTransporter={() => console.log('swap')}
+      />
+    );
+    screen.getAllByRole('button').forEach((button) => {
+      if (button.classList.contains('text-secondary')) {
+        expect(button).toBeDisabled();
+      } else {
+        expect(button).not.toBeDisabled();
+      }
+    });
+  });
+});

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
@@ -30,6 +30,7 @@ function TransporterRowActions({
     <div className="d-flex justify-content-between mx-0">
       {/* Move Transporter up (towards the front of the transporter list) */}
       <Button
+        title={`move-transporter-${index}-up-button`}
         // If first transporter, disable move up button and color gray
         disabled={isFirst}
         className={`${
@@ -43,7 +44,7 @@ function TransporterRowActions({
       </Button>
       {/* Move Transporter down (towards the back of the transporter list) */}
       <Button
-        id={`transporter-down-button-${index}`}
+        title={`move-transporter-${index}-down-button`}
         // If last transporter, disable move down button and color gray
         disabled={isLast}
         className={`${
@@ -57,6 +58,7 @@ function TransporterRowActions({
       </Button>
       {/* Remove Transporter */}
       <Button
+        title={`remove-transporter-${index}-button`}
         className="text-danger m-0 p-0 bg-transparent border-0"
         onClick={() => {
           removeTransporter(index);

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
@@ -43,6 +43,7 @@ function TransporterRowActions({
       </Button>
       {/* Move Transporter down (towards the back of the transporter list) */}
       <Button
+        id={`transporter-down-button-${index}`}
         // If last transporter, disable move down button and color gray
         disabled={isLast}
         className={`${
@@ -56,12 +57,12 @@ function TransporterRowActions({
       </Button>
       {/* Remove Transporter */}
       <Button
-        className="m-0 p-0 bg-transparent border-0"
+        className="text-danger m-0 p-0 bg-transparent border-0"
         onClick={() => {
           removeTransporter(index);
         }}
       >
-        <i className="text-danger fas fa-times-circle fa-xl"></i>
+        <i className="fas fa-times-circle fa-xl"></i>
       </Button>
     </div>
   );

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
@@ -1,31 +1,49 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import { UseFieldArrayRemove } from 'react-hook-form';
+import { UseFieldArrayRemove, UseFieldArraySwap } from 'react-hook-form';
 
-interface Props {
-  order: number;
+interface TranRowActionProps {
+  index: number;
+  length: number;
   removeTransporter: UseFieldArrayRemove;
+  swapTransporter: UseFieldArraySwap;
 }
 
-function TransporterRowActions({ order, removeTransporter }: Props) {
+function TransporterRowActions({
+  index,
+  removeTransporter,
+  swapTransporter,
+  length,
+}: TranRowActionProps) {
+  console.log(index);
+  console.log(length);
   return (
     <div className="d-flex justify-content-between mx-0">
+      {/* Move Transporter up (towards the front of the transporter list) */}
       <Button
+        disabled={index === 0}
         className="m-0 p-0 bg-transparent border-0"
-        onClick={() => console.log('hello')}
+        onClick={() => {
+          swapTransporter(index, index - 1);
+        }}
       >
         <i className="text-primary fas fa-arrow-circle-up fa-lg"></i>
       </Button>
+      {/* Move Transporter down (towards the back of the transporter list) */}
       <Button
+        disabled={index + 1 === length}
         className="m-0 p-0 bg-transparent border-0"
-        onClick={() => console.log('hello')}
+        onClick={() => {
+          swapTransporter(index, index + 1);
+        }}
       >
         <i className="text-primary fas fa-arrow-circle-down fa-lg"></i>
       </Button>
+      {/* Remove Transporter */}
       <Button
         className="m-0 p-0 bg-transparent border-0"
         onClick={() => {
-          removeTransporter(order);
+          removeTransporter(index);
         }}
       >
         <i className="text-danger fas fa-times-circle fa-lg"></i>

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterRowActions.tsx
@@ -9,35 +9,50 @@ interface TranRowActionProps {
   swapTransporter: UseFieldArraySwap;
 }
 
+/**
+ * TransporterRowActions uses index and length to disable and display
+ * different actions for eah row, expected to be part of a mapped table or list.
+ * @param index
+ * @param removeTransporter
+ * @param swapTransporter
+ * @param length
+ * @constructor
+ */
 function TransporterRowActions({
   index,
   removeTransporter,
   swapTransporter,
   length,
 }: TranRowActionProps) {
-  console.log(index);
-  console.log(length);
+  const isFirst = index === 0;
+  const isLast = index + 1 === length;
   return (
     <div className="d-flex justify-content-between mx-0">
       {/* Move Transporter up (towards the front of the transporter list) */}
       <Button
-        disabled={index === 0}
-        className="m-0 p-0 bg-transparent border-0"
+        // If first transporter, disable move up button and color gray
+        disabled={isFirst}
+        className={`${
+          isFirst ? 'text-secondary' : 'text-primary'
+        } m-0 p-0 border-0 bg-transparent`}
         onClick={() => {
           swapTransporter(index, index - 1);
         }}
       >
-        <i className="text-primary fas fa-arrow-circle-up fa-lg"></i>
+        <i className="fas fa-arrow-circle-up fa-xl"></i>
       </Button>
       {/* Move Transporter down (towards the back of the transporter list) */}
       <Button
-        disabled={index + 1 === length}
-        className="m-0 p-0 bg-transparent border-0"
+        // If last transporter, disable move down button and color gray
+        disabled={isLast}
+        className={`${
+          isLast ? 'text-secondary' : 'text-primary'
+        } m-0 p-0 border-0 bg-transparent`}
         onClick={() => {
           swapTransporter(index, index + 1);
         }}
       >
-        <i className="text-primary fas fa-arrow-circle-down fa-lg"></i>
+        <i className="fas fa-arrow-circle-down fa-xl"></i>
       </Button>
       {/* Remove Transporter */}
       <Button
@@ -46,7 +61,7 @@ function TransporterRowActions({
           removeTransporter(index);
         }}
       >
-        <i className="text-danger fas fa-times-circle fa-lg"></i>
+        <i className="text-danger fas fa-times-circle fa-xl"></i>
       </Button>
     </div>
   );

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.spec.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { renderWithProviders } from 'test';
+import { screen } from '@testing-library/react';
+import { TransporterTable } from './index';
+import { Transporter } from 'types/Transporter/Transporter';
+
+const HANDLER_ID_1 = 'siteId1';
+const HANDLER_ID_2 = 'siteId2';
+
+const HANDLER_OBJECT = {
+  epaSiteId: HANDLER_ID_1,
+  siteType: 'Generator',
+  name: 'TEST TRANSPORTER 2 OF VA',
+  siteAddress: {
+    streetNumber: '123',
+    address1: 'VA TEST GEN 2021 WAY',
+    city: 'Arlington',
+    state: {
+      code: 'VA',
+      name: 'Virginia',
+    },
+    country: {
+      code: 'US',
+      name: 'United States',
+    },
+    zip: '20022',
+  },
+  mailingAddress: {
+    streetNumber: '123',
+    address1: 'VA TEST GEN 2021 WAY',
+    city: 'Arlington',
+    state: {
+      code: 'VA',
+      name: 'Virginia',
+    },
+    country: {
+      code: 'US',
+      name: 'United States',
+    },
+    zip: '20022',
+  },
+  contact: {
+    phone: {
+      number: '703-308-0023',
+    },
+    email: 'Testing@EPA.GOV',
+  },
+  emergencyPhone: {
+    number: '888-456-1234',
+  },
+  electronicSignatureInfo: [
+    {
+      humanReadableDocument: {
+        name: 'human-readable.html',
+        size: 177949,
+        mimeType: 'TEXT_HTML',
+      },
+    },
+  ],
+  hasRegisteredEmanifestUser: true,
+  gisPrimary: false,
+};
+
+const TRAN_ARRAY: Array<Transporter> = [
+  {
+    ...HANDLER_OBJECT,
+    order: 1,
+  },
+  {
+    ...HANDLER_OBJECT,
+    epaSiteId: HANDLER_ID_2,
+    order: 2,
+  },
+];
+
+describe('TransporterTable', () => {
+  test('renders transporter', () => {
+    /**
+     * We're not going to mock the useFieldArray, opt for integration test.
+     * This weak unit test just checks if an existing array of transporters is
+     * rendered in the table
+     */
+    const fakeArrayMethods = {};
+    const { debug } = renderWithProviders(
+      <TransporterTable
+        // @ts-ignore
+        arrayFieldMethods={fakeArrayMethods}
+        transporters={TRAN_ARRAY}
+      />,
+      {}
+    );
+    expect(screen.getByText(HANDLER_ID_1)).toBeInTheDocument();
+    expect(screen.getByText(HANDLER_ID_2)).toBeInTheDocument();
+    debug(undefined, Infinity);
+  });
+});

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.spec.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.spec.tsx
@@ -74,14 +74,10 @@ const TRAN_ARRAY: Array<Transporter> = [
 ];
 
 describe('TransporterTable', () => {
-  test('renders transporter', () => {
-    /**
-     * We're not going to mock the useFieldArray, opt for integration test.
-     * This weak unit test just checks if an existing array of transporters is
-     * rendered in the table
-     */
-    const fakeArrayMethods = {};
-    const { debug } = renderWithProviders(
+  test('renders an array of transporter', () => {
+    // We're not going to mock the useFieldArray, opt for integration test.
+    const fakeArrayMethods = {}; // non-existent method placeholders
+    renderWithProviders(
       <TransporterTable
         // @ts-ignore
         arrayFieldMethods={fakeArrayMethods}
@@ -91,6 +87,62 @@ describe('TransporterTable', () => {
     );
     expect(screen.getByText(HANDLER_ID_1)).toBeInTheDocument();
     expect(screen.getByText(HANDLER_ID_2)).toBeInTheDocument();
-    debug(undefined, Infinity);
+    // debug(undefined, Infinity);
+  });
+  test('renders actions for each transporter', () => {
+    const fakeArrayMethods = {}; // non-existent method placeholders
+    const { debug } = renderWithProviders(
+      <TransporterTable
+        // @ts-ignore
+        arrayFieldMethods={fakeArrayMethods}
+        transporters={TRAN_ARRAY}
+      />,
+      {}
+    );
+    for (let i = 0; i < TRAN_ARRAY.length; i++) {
+      expect(
+        screen.getByTitle(`remove-transporter-${i}-button`)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`move-transporter-${i}-down-button`)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTitle(`move-transporter-${i}-up-button`)
+      ).toBeInTheDocument();
+    }
+    expect(
+      screen.getByTitle(`move-transporter-${TRAN_ARRAY.length - 1}-down-button`)
+    ).toBeDisabled();
+  });
+  test('first move-up and last move-down to be disabled', () => {
+    const fakeArrayMethods = {}; // non-existent method placeholders
+    const { debug } = renderWithProviders(
+      <TransporterTable
+        // @ts-ignore
+        arrayFieldMethods={fakeArrayMethods}
+        transporters={TRAN_ARRAY}
+      />,
+      {}
+    );
+    for (let i = 0; i < TRAN_ARRAY.length; i++) {
+      if (i === 0) {
+        expect(
+          screen.getByTitle(`move-transporter-${i}-up-button`)
+        ).toBeDisabled();
+      } else {
+        expect(
+          screen.getByTitle(`move-transporter-${i}-up-button`)
+        ).not.toBeDisabled();
+      }
+      if (i === TRAN_ARRAY.length - 1) {
+        expect(
+          screen.getByTitle(`move-transporter-${i}-down-button`)
+        ).toBeDisabled();
+      } else {
+        expect(
+          screen.getByTitle(`move-transporter-${i}-down-button`)
+        ).not.toBeDisabled();
+      }
+    }
   });
 });

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { Table } from 'react-bootstrap';
-import { Handler } from 'types';
+import { Handler, Manifest } from 'types';
 import { TransporterRowActions } from './TransporterRowActions';
-import { UseFieldArrayRemove } from 'react-hook-form';
+import { UseFieldArrayReturn } from 'react-hook-form';
 
 interface TransporterTableProps {
   transporters?: Array<Handler>;
-  removeTransporter: UseFieldArrayRemove;
+  arrayFieldMethods: UseFieldArrayReturn<Manifest, 'transporters', 'id'>;
 }
 
 function TransporterTable({
   transporters,
-  removeTransporter,
+  arrayFieldMethods,
 }: TransporterTableProps) {
   if (!transporters || transporters.length < 1) {
     return <></>;
@@ -43,8 +43,10 @@ function TransporterTable({
               <td>{transporter.canEsign ? 'yes' : 'no'}</td>
               <td>
                 <TransporterRowActions
-                  removeTransporter={removeTransporter}
-                  order={index}
+                  removeTransporter={arrayFieldMethods.remove}
+                  swapTransporter={arrayFieldMethods.swap}
+                  index={index}
+                  length={transporters?.length}
                 />
               </td>
             </tr>

--- a/client/src/types/Manifest/Contact.ts
+++ b/client/src/types/Manifest/Contact.ts
@@ -1,9 +1,9 @@
 export interface Contact {
-  firstName: string;
-  middleInitial: string;
-  lastName: string;
-  phone: Phone;
-  email: string;
+  firstName?: string;
+  middleInitial?: string;
+  lastName?: string;
+  phone?: Phone;
+  email?: string;
   companyName?: string;
 }
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -10,9 +10,9 @@ services:
       - ./server/lib:/app/lib
       - ./server/tests:/app/tests
       - ./server/manage.py:/app/manage.py
-#      - ./server/db.sqlite3:/app/db.sqlite3
+    #      - ./server/db.sqlite3:/app/db.sqlite3
     command: |
-      sh -c "python manage.py makemigrations && python manage.py migrate && python manage.py loaddata ./tests/fixtures/test_data.json && python manage.py runserver 0.0.0.0:8000"
+      sh -c "python manage.py makemigrations && python manage.py migrate && python manage.py loaddata dev_data.json && python manage.py runserver 0.0.0.0:8000"
 
   client:
     extends:

--- a/server/apps/trak/views/handler.py
+++ b/server/apps/trak/views/handler.py
@@ -1,15 +1,19 @@
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import permissions, status
 from rest_framework.exceptions import APIException
+from rest_framework.generics import GenericAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from apps.trak.models import Handler
 from apps.trak.serializers import HandlerSerializer
 
 
-class HandlerView(APIView):
+class HandlerView(GenericAPIView):
+    """
+    HandlerView  provides https handlers for reading handlers from the haztrak database
+
+    """
     response = Response
     permission_classes = [permissions.IsAuthenticated]
 

--- a/server/apps/trak/views/manifest.py
+++ b/server/apps/trak/views/manifest.py
@@ -6,7 +6,11 @@ from apps.trak.serializers import ManifestSerializer
 
 
 class ManifestView(viewsets.ModelViewSet):
-    """Uniform hazardous waste manifest by manifest tracking number (MTN)"""
+    """
+    A model view set for the Uniform hazardous waste manifest, manifest are queried by
+    the manifest tracking number (MTN)
+
+    """
     queryset = Manifest.objects.all()
     lookup_field = 'mtn'
     serializer_class = ManifestSerializer

--- a/server/apps/trak/views/sites.py
+++ b/server/apps/trak/views/sites.py
@@ -15,7 +15,11 @@ from apps.trak.serializers import SiteSerializer
 
 
 class SiteList(generics.ListAPIView):
-    """SiteList returns haztrak sites that a user has access to"""
+    """
+    SiteList is a ListAPIView that returns haztrak sites that the current
+    user has access to.
+
+    """
     serializer_class = SiteSerializer
 
     def get_queryset(self):


### PR DESCRIPTION
## Description
This PR adds the ability to re-order the transporters listed on a draft manifest, as well as tests and some cosmetic aspects of the transporter re-order actions. 

The first row (transporter 1) has its "move up" (move towards the front of the list) button disabled and vice versa for the last transporters and the move down button. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->
closes #202 



## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

