### PR TITLE
removes notification badge when no. of alerts is 0

### DIFF
--- a/client/src/components/Notification/Notification.tsx
+++ b/client/src/components/Notification/Notification.tsx
@@ -21,7 +21,7 @@ function Notification() {
             bsPrefix="badge badge-top-right"
             aria-label="unread Messages"
           >
-            {numberAlerts < 9 ? `${numberAlerts}` : '9+'}
+            {numberAlerts > 0 ? (numberAlerts < 9 ? `${numberAlerts}` : '9+') : null}
           </Badge>
         </Dropdown.Toggle>
         <Dropdown.Menu className="pt-0 alert-mw">


### PR DESCRIPTION
## Description

This commit hides the notification badge when the number of alerts is equal to zero

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->
closes #255 



## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

Below are screenshots to verify my solution

#### When there's no alert messages
![Screenshot 2022-12-31 115717](https://user-images.githubusercontent.com/26011119/210127897-0e3e29e6-677b-4e9e-8122-2a3c91ccb8c1.png)

#### When there's an alert message
![image](https://user-images.githubusercontent.com/26011119/210127924-de0942d3-33b9-4c98-8094-e5d8c40d150c.png)
