### PR TITLE
281 add dev fixtures

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -1,8 +1,8 @@
 name: Github Pages
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U $HT_DB_USER -d $HT_DB_NAME"]
       interval: 3s
       timeout: 3s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,8 @@ services:
       python manage.py loaddata dev_data.json &&
       python manage.py runserver 0.0.0.0:8000"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   redis:
     container_name: ht_redis
@@ -66,6 +67,11 @@ services:
       POSTGRES_PASSWORD: ${HT_DB_PASSWORD}
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
   #    volumes:
   #      - development:/var/lib/postgresql/data
 

--- a/server/fixtures/dev_data.json
+++ b/server/fixtures/dev_data.json
@@ -90,12 +90,20 @@
     "model": "trak.contact",
     "pk": 1,
     "fields": {
-      "first_name": null,
-      "middle_initial": null,
-      "last_name": null,
-      "phone": null,
-      "email": "",
-      "company_name": null
+      "first_name": "David",
+      "middle_initial": "P",
+      "last_name": "Graham",
+      "phone": 1,
+      "email": "testuser1@haztrak.net",
+      "company_name": "haztrak"
+    }
+  },
+  {
+    "model": "trak.epaphone",
+    "pk": 1,
+    "fields": {
+      "number": "321-321-3214",
+      "extension": null
     }
   },
   {

--- a/server/fixtures/dev_data.json
+++ b/server/fixtures/dev_data.json
@@ -50,10 +50,65 @@
       "user": 2,
       "rcra_api_key": "fakeRCRAInfoAPIKey",
       "rcra_api_id": "fakeRCRAInfoAPIId",
-      "rcra_username": "dpgraham4401",
+      "rcra_username": "testuser1",
       "phone_number": null,
-      "epa_sites": [],
+      "epa_sites": [
+        1
+      ],
       "email": "test.user@haztrak.net"
+    }
+  },
+  {
+    "model": "trak.handler",
+    "pk": 1,
+    "fields": {
+      "site_type": "",
+      "epa_id": "VATESTGEN001",
+      "name": "VA TEST GEN 2021",
+      "site_address": 1,
+      "mail_address": 1,
+      "modified": false,
+      "registered": false,
+      "contact": 1,
+      "emergency_phone": null,
+      "electronic_signatures_info": null,
+      "gis_primary": false,
+      "can_esign": true,
+      "limited_esign": true,
+      "registered_emanifest_user": true
+    }
+  },
+  {
+    "model": "trak.site",
+    "pk": 1,
+    "fields": {
+      "name": "VA TEST GEN 2021",
+      "epa_site": 1
+    }
+  },
+  {
+    "model": "trak.contact",
+    "pk": 1,
+    "fields": {
+      "first_name": null,
+      "middle_initial": null,
+      "last_name": null,
+      "phone": null,
+      "email": "",
+      "company_name": null
+    }
+  },
+  {
+    "model": "trak.address",
+    "pk": 1,
+    "fields": {
+      "street_number": null,
+      "address1": "123 VA TEST GEN 2021 WAY",
+      "address2": null,
+      "city": "ARLINGTON",
+      "state": "VA",
+      "country": "US",
+      "zip": "22202"
     }
   }
 ]


### PR DESCRIPTION
## Description

This is a small PR that adds a limited set of fixtures (discussed [here](https://github.com/USEPA/haztrak/issues/281#issuecomment-1374189178)) so developers have  data in the local development environment to work against.

It also has 2 minor fixes
* A healthcheck for the postgres service so the django/celery services don't try to connect to the postgres db too early<sup>1</sup>
* fix gh_pages trigger condition to follow the actions start-workflow examples.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->




## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings



## Other Stuff

<sup>1</sup> The django/celery services sometimes failed, because while the postgres container had been started, the postgres db was not ready to accept connections. This often happened when it was the first time running `docker-compose up`.