### PR TITLE
Added model validation in site_permission

### DIFF
--- a/server/apps/trak/models/site_permission.py
+++ b/server/apps/trak/models/site_permission.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from .rcra_profile import RcraProfile
@@ -50,3 +51,11 @@ class SitePermission(models.Model):
 
     def __str__(self):
         return f'{self.profile.user}: {self.site}'
+
+    def clean(self):
+        if self.site_manager:
+            fields = ['annual_report', 'biennial_report', 'e_manifest', 'my_rcra_id', 'wiets']
+            for field_name in fields:
+                field_value = getattr(self, field_name)
+                if field_value != "Certifier":
+                    raise ValidationError(f"The value for the '{field_name}' field must be set to 'Certifier'.")


### PR DESCRIPTION
## Description
Added a model validation in site_permission that checks the following fields in RCRAInfo modules [annual_report, biennial_report, e_manifest, my_rcra_id, wiets] should be equal to 'Certifier' when site_permission == 'True'.


## Issue ticket number and link
closes #310




## Checklist
<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



## Other Stuff

