### PR TITLE
Quicker sign submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you like the work we do, star this repo for greater visibility.
 ## Getting Started :rocket:
 
 - See our [documentation](https://usepa.github.io/haztrak) for an introduction,
-  as well as detailed instructions on [setting up a local development environment](https://usepa.github.io/haztrak/deploy/local-development.html)
+  as well as detailed instructions on [setting up a local development environment](https://usepa.github.io/haztrak/development/local-development.html)
 - [Contribution guidelines](https://github.com/USEPA/haztrak/blob/main/.github/CONTRIBUTING.md).
 - Find something to work on our [issue tracker](https://github.com/USEPA/haztrak/issues)
   - Don't see something that interests you, [open a new issue](https://github.com/USEPA/haztrak/issues/new/choose)

--- a/client/src/components/HandlerDetails/HandlerDetails.spec.tsx
+++ b/client/src/components/HandlerDetails/HandlerDetails.spec.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
-import { createMockHandler } from 'test-utils/fixtures';
+import { createMockHandler, createMockMTNHandler } from 'test-utils/fixtures';
 import HandlerDetails from './HandlerDetails';
 
 afterEach(() => {
@@ -11,13 +11,13 @@ afterEach(() => {
 
 describe('HandlerDetails', () => {
   test('displays the handlers information', () => {
-    const handler = createMockHandler();
+    const handler = createMockMTNHandler();
     renderWithProviders(<HandlerDetails handler={handler} />);
     expect(screen.getByText(handler.name)).toBeInTheDocument();
     expect(screen.getByText(handler.epaSiteId)).toBeInTheDocument();
   });
   test('does not display undefined when part of address is missing', () => {
-    const minimumAddressHandler = createMockHandler({
+    const minimumAddressHandler = createMockMTNHandler({
       siteAddress: {
         address1: '123 main st.',
         state: { code: 'Tx' },

--- a/client/src/components/HandlerDetails/HandlerDetails.tsx
+++ b/client/src/components/HandlerDetails/HandlerDetails.tsx
@@ -3,10 +3,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import AddressListGroup from 'components/HandlerDetails/AddressListGroup';
 import React from 'react';
 import { Col, Row } from 'react-bootstrap';
-import { ManifestHandler } from 'types/handler';
+import { Handler, ManifestHandler } from 'types/handler';
 
 interface HandlerDetailsProps {
-  handler: ManifestHandler;
+  handler: ManifestHandler | Handler;
 }
 
 /**
@@ -22,7 +22,7 @@ function HandlerDetails({ handler }: HandlerDetailsProps) {
           <h4>{handler.name}</h4>
         </Col>
         <Col className="d-flex justify-content-end">
-          {handler.signed && (
+          {'signed' in handler && handler.signed && (
             <p className="text-right">
               signed <FontAwesomeIcon icon={faSignature} className="text-success" size="xl" />
             </p>

--- a/client/src/components/Ht/HtForm.tsx
+++ b/client/src/components/Ht/HtForm.tsx
@@ -7,6 +7,8 @@ import {
   FormLabelProps,
   FormProps,
   FormSelectProps,
+  InputGroup,
+  InputGroupProps,
 } from 'react-bootstrap';
 
 function HtForm(props: FormProps): ReactElement {
@@ -18,6 +20,14 @@ HtForm.Group = function (props: FormGroupProps): ReactElement {
     <Form.Group {...props} className="mb-2">
       {props.children}
     </Form.Group>
+  );
+};
+
+HtForm.InputGroup = function (props: InputGroupProps): ReactElement {
+  return (
+    <InputGroup {...props} className="mb-2">
+      {props.children}
+    </InputGroup>
   );
 };
 

--- a/client/src/components/Ht/HtPaginate/HtPaginate.spec.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPaginate.spec.tsx
@@ -16,7 +16,7 @@ describe('HtPaginate', () => {
     render(
       <>
         <HtPaginate
-          onPageChange={() => console.log('blah')}
+          onPageChange={() => console.log('mock function')}
           currentPage={defaultCurrentPage}
           totalCount={defaultTotalCount}
           pageSize={defaultPageSize}
@@ -31,7 +31,7 @@ describe('HtPaginate', () => {
     render(
       <>
         <HtPaginate
-          onPageChange={() => console.log('blah')}
+          onPageChange={() => console.log('mock function')}
           currentPage={defaultCurrentPage}
           totalCount={defaultTotalCount}
           pageSize={defaultPageSize + defaultTotalCount}
@@ -44,7 +44,7 @@ describe('HtPaginate', () => {
     render(
       <>
         <HtPaginate
-          onPageChange={() => console.log('blah')}
+          onPageChange={() => console.log('mock function')}
           currentPage={defaultCurrentPage}
           totalCount={defaultTotalCount + 100}
           pageSize={defaultPageSize}

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -110,6 +110,11 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
   const toggleTsdfFormShow = () => setTsdfFormShow(!tsdfFormShow);
   const tsdf: ManifestHandler = manifestMethods.getValues('designatedFacility');
 
+  const signAble =
+    manifestData?.status === 'Scheduled' ||
+    manifestData?.status === 'InTransit' ||
+    manifestData?.status === 'ReadyForSignature';
+
   return (
     <>
       <FormProvider {...manifestMethods}>
@@ -259,7 +264,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                         siteType={'Generator'}
                         mtnHandler={generator}
                         handleClick={setupSign}
-                        disabled={generator.signed}
+                        disabled={generator.signed || !signAble}
                       />
                     </Col>
                   </div>
@@ -320,7 +325,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                         siteType={'Tsdf'}
                         mtnHandler={tsdf}
                         handleClick={setupSign}
-                        disabled={tsdf.signed}
+                        disabled={tsdf.signed || !signAble}
                       />
                     </Col>
                   </div>

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -27,6 +27,11 @@ interface ManifestFormProps {
   mtn?: string;
 }
 
+interface QuickerSignData {
+  handler: ManifestHandler | undefined;
+  siteType: 'Generator' | 'Transporter' | 'Tsdf';
+}
+
 /**
  * Returns form for the uniform hazardous waste manifest. It also acts
  * as the current method of viewing manifest when the form is read only.
@@ -81,19 +86,20 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
   });
   // Quicker Sign controls
   const [quickerSignShow, setQuickerSignShow] = useState<boolean>(false);
-  const [quickerSignHandler, setQuickerSignHandler] = useState<ManifestHandler | undefined>(
-    undefined
-  );
+  const [quickerSignHandler, setQuickerSignHandler] = useState<QuickerSignData>({
+    handler: undefined,
+    siteType: 'Generator',
+  });
   /**
    * Convenience function to toggle Quicker Sign form
    */
   const toggleQuickerSignShow = () => setQuickerSignShow(!quickerSignShow);
   /**
-   * Convenience function to state for controlling which ManifestHandler will be quicker signing
+   * Closure for controlling which ManifestHandler will be quicker signing
    * and toggle to modal that displays our Quicker Sign form.
    */
-  const setupQuickerSign = (handler: ManifestHandler | undefined) => {
-    setQuickerSignHandler(handler);
+  const setupQuickerSign = (handlerData: QuickerSignData) => {
+    setQuickerSignHandler(handlerData);
     toggleQuickerSignShow();
   };
 
@@ -258,7 +264,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                     <HtButton
                       align="end"
                       onClick={() => {
-                        setupQuickerSign(generator);
+                        setupQuickerSign({ handler: generator, siteType: 'Generator' });
                       }}
                       disabled={generator.signed}
                     >
@@ -319,9 +325,9 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                     <HtButton
                       align="end"
                       onClick={() => {
-                        setupQuickerSign(tsdf);
+                        setupQuickerSign({ handler: tsdf, siteType: 'Tsdf' });
                       }}
-                      disabled={generator.signed}
+                      disabled={tsdf.signed}
                     >
                       Quicker Sign
                     </HtButton>
@@ -382,7 +388,8 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
           handleClose={toggleQuickerSignShow}
           show={quickerSignShow}
           mtn={[mtn ? mtn : '']}
-          mtnHandler={quickerSignHandler}
+          mtnHandler={quickerSignHandler.handler}
+          siteType={quickerSignHandler.siteType}
         />
         <AddWasteLine
           appendWaste={wasteArrayMethods.append}

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -1,4 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios';
+import { RcraApiUserBtn } from 'components/buttons';
 import { HtButton, HtCard, HtForm } from 'components/Ht';
 import HandlerDetails from 'components/HandlerDetails';
 import HtP from 'components/Ht/HtP';
@@ -18,7 +19,7 @@ import { WasteLine } from 'types/wasteLine';
 import HandlerForm from './HandlerForm';
 import AddTsdf from './Tsdf';
 import AddWasteLine from './WasteLine';
-import { QuickerSignModal } from 'components/QuickerSign';
+import { QuickerSignModal, QuickerSignModalBtn } from 'components/QuickerSign';
 
 interface ManifestFormProps {
   readOnly?: boolean;
@@ -261,15 +262,14 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                   <ContactForm handlerFormType="generator" readOnly={readOnly} />
                   <div className="d-flex justify-content-between">
                     {/* Button to bring up the Quicker Sign modal*/}
-                    <HtButton
-                      align="end"
-                      onClick={() => {
-                        setupQuickerSign({ handler: generator, siteType: 'Generator' });
-                      }}
-                      disabled={generator.signed}
-                    >
-                      Quicker Sign
-                    </HtButton>
+                    <Col className="text-end">
+                      <QuickerSignModalBtn
+                        siteType={'Generator'}
+                        mtnHandler={generator}
+                        handleClick={setupQuickerSign}
+                        disabled={generator.signed}
+                      />
+                    </Col>
                   </div>
                 </>
               ) : (
@@ -322,15 +322,14 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                   <HandlerDetails handler={tsdf} />
                   <div className="d-flex justify-content-between">
                     {/* Button to bring up the Quicker Sign modal*/}
-                    <HtButton
-                      align="end"
-                      onClick={() => {
-                        setupQuickerSign({ handler: tsdf, siteType: 'Tsdf' });
-                      }}
-                      disabled={tsdf.signed}
-                    >
-                      Quicker Sign
-                    </HtButton>
+                    <Col className="text-end">
+                      <QuickerSignModalBtn
+                        siteType={'Tsdf'}
+                        mtnHandler={tsdf}
+                        handleClick={setupQuickerSign}
+                        disabled={tsdf.signed}
+                      />
+                    </Col>
                   </div>
                 </>
               ) : (

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -1,5 +1,4 @@
 import { AxiosError, AxiosResponse } from 'axios';
-import { RcraApiUserBtn } from 'components/buttons';
 import { HtButton, HtCard, HtForm } from 'components/Ht';
 import HandlerDetails from 'components/HandlerDetails';
 import HtP from 'components/Ht/HtP';
@@ -15,6 +14,7 @@ import htApi from 'services';
 import { addMsg, useAppDispatch } from 'store';
 import { Manifest } from 'types/manifest';
 import { HandlerType, ManifestHandler, Transporter } from 'types/handler';
+import { QuickerSignData } from 'types/manifest/signatures';
 import { WasteLine } from 'types/wasteLine';
 import HandlerForm from './HandlerForm';
 import AddTsdf from './Tsdf';
@@ -26,11 +26,6 @@ interface ManifestFormProps {
   manifestData?: Manifest;
   siteId?: string;
   mtn?: string;
-}
-
-interface QuickerSignData {
-  handler: ManifestHandler | undefined;
-  siteType: 'Generator' | 'Transporter' | 'Tsdf';
 }
 
 /**
@@ -85,23 +80,20 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
     control: manifestMethods.control,
     name: 'transporters',
   });
+
   // Quicker Sign controls
   const [quickerSignShow, setQuickerSignShow] = useState<boolean>(false);
   const [quickerSignHandler, setQuickerSignHandler] = useState<QuickerSignData>({
     handler: undefined,
-    siteType: 'Generator',
+    siteType: 'Generator', // ToDo initialize to undefined
   });
-  /**
-   * Convenience function to toggle Quicker Sign form
-   */
   const toggleQuickerSignShow = () => setQuickerSignShow(!quickerSignShow);
   /**
-   * Closure for controlling which ManifestHandler will be quicker signing
-   * and toggle to modal that displays our Quicker Sign form.
+   * function used to control the QuickerSign form (modal) and pass the necessary context
    */
-  const setupQuickerSign = (handlerData: QuickerSignData) => {
-    setQuickerSignHandler(handlerData);
-    toggleQuickerSignShow();
+  const setupSign = (signContext: QuickerSignData) => {
+    setQuickerSignHandler(signContext); // set state to appropriate ManifestHandler
+    toggleQuickerSignShow(); // Toggle the Quicker Sign modal
   };
 
   // WasteLine controls
@@ -266,7 +258,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       <QuickerSignModalBtn
                         siteType={'Generator'}
                         mtnHandler={generator}
-                        handleClick={setupQuickerSign}
+                        handleClick={setupSign}
                         disabled={generator.signed}
                       />
                     </Col>
@@ -289,6 +281,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                 transporters={transporters}
                 arrayFieldMethods={tranArrayMethods}
                 readOnly={readOnly}
+                setupSign={setupSign}
               />
               {readOnly ? (
                 <></>
@@ -326,7 +319,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       <QuickerSignModalBtn
                         siteType={'Tsdf'}
                         mtnHandler={tsdf}
-                        handleClick={setupQuickerSign}
+                        handleClick={setupSign}
                         disabled={tsdf.signed}
                       />
                     </Col>

--- a/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
+++ b/client/src/components/ManifestForm/Transporter/TransporterTable/TransporterTable.tsx
@@ -1,8 +1,10 @@
 import { faCircleCheck, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import { QuickerSignModalBtn } from 'components/QuickerSign';
 import React from 'react';
 import { Table } from 'react-bootstrap';
 import { Manifest } from 'types/manifest';
 import { Transporter } from 'types/handler';
+import { QuickerSignData } from 'types/manifest/signatures';
 import { TransporterRowActions } from './TransporterRowActions';
 import { UseFieldArrayReturn } from 'react-hook-form';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -11,9 +13,15 @@ interface TransporterTableProps {
   transporters?: Array<Transporter>;
   arrayFieldMethods: UseFieldArrayReturn<Manifest, 'transporters', 'id'>;
   readOnly?: boolean;
+  setupSign: (data: QuickerSignData) => void;
 }
 
-function TransporterTable({ transporters, arrayFieldMethods, readOnly }: TransporterTableProps) {
+function TransporterTable({
+  transporters,
+  arrayFieldMethods,
+  readOnly,
+  setupSign,
+}: TransporterTableProps) {
   if (!transporters || transporters.length < 1) {
     return <></>;
   }
@@ -31,7 +39,7 @@ function TransporterTable({ transporters, arrayFieldMethods, readOnly }: Transpo
           <th>EPA ID</th>
           <th>Name</th>
           <th className="text-center">Signed</th>
-          {readOnly ? <></> : <th className="text-center">Edit</th>}
+          <th className="text-center">Edit</th>
         </tr>
       </thead>
       <tbody>
@@ -50,7 +58,13 @@ function TransporterTable({ transporters, arrayFieldMethods, readOnly }: Transpo
               </td>
               <td>
                 {readOnly ? (
-                  <></>
+                  <QuickerSignModalBtn
+                    siteType={'Transporter'}
+                    mtnHandler={transporter}
+                    handleClick={setupSign}
+                    iconOnly={true}
+                    disabled={transporter.signed}
+                  />
                 ) : (
                   <TransporterRowActions
                     removeTransporter={arrayFieldMethods.remove}

--- a/client/src/components/QuickerSign/QuickerSign.spec.tsx
+++ b/client/src/components/QuickerSign/QuickerSign.spec.tsx
@@ -2,19 +2,19 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { createMockMTNHandler } from 'test-utils/fixtures';
-import QuickerSign from './QuickerSign';
+import QuickerSignForm from 'components/QuickerSign/QuickerSignForm';
 
 afterEach(() => {
   cleanup();
   jest.resetAllMocks();
 });
 
-describe('QuickerSign', () => {
+describe('QuickerSignForm', () => {
   test('displays the MTN to be signed', () => {
     const manifestTrackingNumbers: Array<string> = ['123456789ELC', '987654321ELC'];
     const handler = createMockMTNHandler();
     renderWithProviders(
-      <QuickerSign mtn={manifestTrackingNumbers} mtnHandler={handler} siteType={'Generator'} />
+      <QuickerSignForm mtn={manifestTrackingNumbers} mtnHandler={handler} siteType={'Generator'} />
     );
     for (const mtn of manifestTrackingNumbers) {
       expect(screen.getByText(mtn)).toBeInTheDocument();
@@ -24,7 +24,7 @@ describe('QuickerSign', () => {
     const manifestTrackingNumbers: Array<string> = ['123456789ELC', '987654321ELC'];
     const handler = createMockMTNHandler();
     renderWithProviders(
-      <QuickerSign mtn={manifestTrackingNumbers} mtnHandler={handler} siteType={'Generator'} />
+      <QuickerSignForm mtn={manifestTrackingNumbers} mtnHandler={handler} siteType={'Generator'} />
     );
     expect(screen.getByText(new RegExp(`${handler.epaSiteId}`))).toBeInTheDocument();
   });

--- a/client/src/components/QuickerSign/QuickerSign.spec.tsx
+++ b/client/src/components/QuickerSign/QuickerSign.spec.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
-import { createMockHandler } from 'test-utils/fixtures';
+import { createMockMTNHandler } from 'test-utils/fixtures';
 import QuickerSign from './QuickerSign';
 
 afterEach(() => {
@@ -12,16 +12,20 @@ afterEach(() => {
 describe('QuickerSign', () => {
   test('displays the MTN to be signed', () => {
     const manifestTrackingNumbers: Array<string> = ['123456789ELC', '987654321ELC'];
-    const handler = createMockHandler();
-    renderWithProviders(<QuickerSign mtn={manifestTrackingNumbers} mtnHandler={handler} />);
+    const handler = createMockMTNHandler();
+    renderWithProviders(
+      <QuickerSign mtn={manifestTrackingNumbers} mtnHandler={handler} siteType={'Generator'} />
+    );
     for (const mtn of manifestTrackingNumbers) {
       expect(screen.getByText(mtn)).toBeInTheDocument();
     }
   });
   test('shows what site is signing', () => {
     const manifestTrackingNumbers: Array<string> = ['123456789ELC', '987654321ELC'];
-    const handler = createMockHandler();
-    renderWithProviders(<QuickerSign mtn={manifestTrackingNumbers} mtnHandler={handler} />);
+    const handler = createMockMTNHandler();
+    renderWithProviders(
+      <QuickerSign mtn={manifestTrackingNumbers} mtnHandler={handler} siteType={'Generator'} />
+    );
     expect(screen.getByText(new RegExp(`${handler.epaSiteId}`))).toBeInTheDocument();
   });
 });

--- a/client/src/components/QuickerSign/QuickerSign.tsx
+++ b/client/src/components/QuickerSign/QuickerSign.tsx
@@ -11,10 +11,18 @@ import { useNavigate } from 'react-router-dom';
 interface QuickerSignProps {
   mtn: Array<string>;
   mtnHandler: ManifestHandler;
+  siteType: 'Generator' | 'Transporter' | 'Tsdf';
+  transporterOrder?: number;
   handleClose?: () => void;
 }
 
-function QuickerSign({ mtn, mtnHandler, handleClose }: QuickerSignProps) {
+function QuickerSign({
+  mtn,
+  mtnHandler,
+  handleClose,
+  siteType,
+  transporterOrder,
+}: QuickerSignProps) {
   const { register, handleSubmit } = useForm<QuickerSignature>();
   const navigate = useNavigate();
   if (!handleClose) {
@@ -23,7 +31,14 @@ function QuickerSign({ mtn, mtnHandler, handleClose }: QuickerSignProps) {
   }
 
   const onSubmit: SubmitHandler<QuickerSignature> = (data) => {
-    console.log(data);
+    const signature: QuickerSignature = {
+      printedSignatureDate: data.printedSignatureDate,
+      printedSignatureName: data.printedSignatureName,
+      siteId: mtnHandler.epaSiteId,
+      siteType: siteType,
+      manifestTrackingNumbers: mtn,
+    };
+    console.log(signature);
   };
 
   return (

--- a/client/src/components/QuickerSign/QuickerSignForm.tsx
+++ b/client/src/components/QuickerSign/QuickerSignForm.tsx
@@ -48,7 +48,6 @@ function QuickerSignForm({ mtn, mtnHandler, handleClose, siteType }: QuickerSign
         transporterOrder: mtnHandler.order,
       };
     }
-    console.log(signature);
     htApi
       .post('/trak/manifest/sign', signature)
       .then((response: AxiosResponse) => {
@@ -56,7 +55,7 @@ function QuickerSignForm({ mtn, mtnHandler, handleClose, siteType }: QuickerSign
           addMsg({
             uniqueId: Date.now(),
             createdDate: new Date().toISOString(),
-            message: `${response} ${response.statusText}`,
+            message: `${response.data.task} ${response.statusText}`,
             alertType: 'Info',
             read: false,
             timeout: 5000,
@@ -75,6 +74,9 @@ function QuickerSignForm({ mtn, mtnHandler, handleClose, siteType }: QuickerSign
           })
         );
       });
+    if (handleClose) {
+      handleClose();
+    }
   };
 
   return (

--- a/client/src/components/QuickerSign/QuickerSignModal.tsx
+++ b/client/src/components/QuickerSign/QuickerSignModal.tsx
@@ -1,7 +1,7 @@
 import { HtModal } from 'components/Ht';
 import React from 'react';
 import { ManifestHandler } from 'types/handler';
-import QuickerSign from './QuickerSign';
+import QuickerSignForm from 'components/QuickerSign/QuickerSignForm';
 
 interface QuickerSignModalProps {
   handleClose: () => void;
@@ -20,7 +20,7 @@ function QuickerSignModal({ handleClose, show, mtn, mtnHandler, siteType }: Quic
         </HtModal.Header>
         <HtModal.Body>
           {mtn && mtnHandler && (
-            <QuickerSign
+            <QuickerSignForm
               mtn={mtn}
               mtnHandler={mtnHandler}
               handleClose={handleClose}

--- a/client/src/components/QuickerSign/QuickerSignModal.tsx
+++ b/client/src/components/QuickerSign/QuickerSignModal.tsx
@@ -1,16 +1,17 @@
 import { HtModal } from 'components/Ht';
 import React from 'react';
-import { Handler } from 'types/handler';
+import { ManifestHandler } from 'types/handler';
 import QuickerSign from './QuickerSign';
 
 interface QuickerSignModalProps {
   handleClose: () => void;
   show: boolean;
   mtn?: Array<string>;
-  mtnHandler?: Handler;
+  mtnHandler?: ManifestHandler;
+  siteType: 'Generator' | 'Transporter' | 'Tsdf';
 }
 
-function QuickerSignModal({ handleClose, show, mtn, mtnHandler }: QuickerSignModalProps) {
+function QuickerSignModal({ handleClose, show, mtn, mtnHandler, siteType }: QuickerSignModalProps) {
   return (
     <>
       <HtModal showModal={show} handleClose={handleClose}>
@@ -19,7 +20,12 @@ function QuickerSignModal({ handleClose, show, mtn, mtnHandler }: QuickerSignMod
         </HtModal.Header>
         <HtModal.Body>
           {mtn && mtnHandler && (
-            <QuickerSign mtn={mtn} mtnHandler={mtnHandler} handleClose={handleClose} />
+            <QuickerSign
+              mtn={mtn}
+              mtnHandler={mtnHandler}
+              handleClose={handleClose}
+              siteType={siteType}
+            />
           )}
         </HtModal.Body>
       </HtModal>

--- a/client/src/components/QuickerSign/QuickerSignModalBtn.tsx
+++ b/client/src/components/QuickerSign/QuickerSignModalBtn.tsx
@@ -1,0 +1,43 @@
+import { faFeather } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+import { ButtonProps } from 'react-bootstrap';
+import { RcraApiUserBtn } from 'components/buttons';
+import { ManifestHandler } from 'types/handler';
+
+interface QuickerSignData {
+  handler: ManifestHandler | undefined;
+  siteType: 'Generator' | 'Transporter' | 'Tsdf';
+}
+
+interface QuickerSignModalBtnProps extends ButtonProps {
+  siteType: 'Generator' | 'Transporter' | 'Tsdf';
+  mtnHandler: ManifestHandler;
+  handleClick: (data: QuickerSignData) => void;
+}
+
+/**
+ * Button for initiating a task to pull manifests from RCRAInfo for a given site
+ * The button will be disabled if siteId (the EPA ID number) is not provided
+ * @constructor
+ */
+function QuickerSignModalBtn({
+  siteType,
+  mtnHandler,
+  handleClick,
+  disabled,
+}: QuickerSignModalBtnProps) {
+  return (
+    <RcraApiUserBtn
+      onClick={() => {
+        handleClick({ handler: mtnHandler, siteType: siteType });
+      }}
+      disabled={disabled}
+    >
+      {`Quicker Sign `}
+      <FontAwesomeIcon icon={faFeather} />
+    </RcraApiUserBtn>
+  );
+}
+
+export default QuickerSignModalBtn;

--- a/client/src/components/QuickerSign/QuickerSignModalBtn.tsx
+++ b/client/src/components/QuickerSign/QuickerSignModalBtn.tsx
@@ -14,6 +14,7 @@ interface QuickerSignModalBtnProps extends ButtonProps {
   siteType: 'Generator' | 'Transporter' | 'Tsdf';
   mtnHandler: ManifestHandler;
   handleClick: (data: QuickerSignData) => void;
+  iconOnly?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ function QuickerSignModalBtn({
   mtnHandler,
   handleClick,
   disabled,
+  iconOnly = false,
 }: QuickerSignModalBtnProps) {
   return (
     <RcraApiUserBtn
@@ -34,7 +36,7 @@ function QuickerSignModalBtn({
       }}
       disabled={disabled}
     >
-      {`Quicker Sign `}
+      {iconOnly ? '' : 'Quicker Sign '}
       <FontAwesomeIcon icon={faFeather} />
     </RcraApiUserBtn>
   );

--- a/client/src/components/QuickerSign/index.ts
+++ b/client/src/components/QuickerSign/index.ts
@@ -1,6 +1,6 @@
-import QuickerSign from './QuickerSign';
+import QuickerSignForm from 'components/QuickerSign/QuickerSignForm';
 import QuickerSignModal from './QuickerSignModal';
 import QuickerSignModalBtn from './QuickerSignModalBtn';
 
-export default QuickerSign;
+export default QuickerSignForm;
 export { QuickerSignModal, QuickerSignModalBtn };

--- a/client/src/components/QuickerSign/index.ts
+++ b/client/src/components/QuickerSign/index.ts
@@ -1,5 +1,6 @@
 import QuickerSign from './QuickerSign';
 import QuickerSignModal from './QuickerSignModal';
+import QuickerSignModalBtn from './QuickerSignModalBtn';
 
 export default QuickerSign;
-export { QuickerSignModal };
+export { QuickerSignModal, QuickerSignModalBtn };

--- a/client/src/components/buttons/RcraApiUserBtn/RcraApiUserBtn.tsx
+++ b/client/src/components/buttons/RcraApiUserBtn/RcraApiUserBtn.tsx
@@ -17,6 +17,7 @@ function RcraApiUserBtn(props: HtApiUserBtnProps) {
   // In order for the button to be active,
   // the disabled prop needs to be falsy AND the user needs to be an API user
   const active = !btnProps.disabled && profile.apiUser;
+
   return (
     <Button {...btnProps} disabled={!active}>
       {props.children}

--- a/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
+++ b/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
@@ -6,7 +6,7 @@ import { RcraApiUserBtn } from 'components/buttons';
 import { addMsg, useAppDispatch } from 'store';
 
 interface SyncManifestProps {
-  siteId: string;
+  siteId?: string;
   disabled?: boolean;
 }
 
@@ -18,21 +18,18 @@ interface SyncManifestProps {
 function SyncManifestBtn({ siteId, disabled }: SyncManifestProps) {
   const [syncingMtn, setSyncingMtn] = useState(false);
   const dispatch = useAppDispatch();
-
-  if (!siteId || disabled) {
-    disabled = true;
-  }
+  let active: boolean = siteId ? true : false;
+  active = !disabled;
 
   return (
     <RcraApiUserBtn
       variant="primary"
-      disabled={disabled}
+      disabled={!active}
       className="mx-2"
       onClick={() => {
         setSyncingMtn(!syncingMtn);
         htApi
           .post('/trak/site/manifest/sync', { siteId: `${siteId}` })
-          .then((r) => console.log(r))
           .then(() => {
             dispatch(
               addMsg({
@@ -45,7 +42,7 @@ function SyncManifestBtn({ siteId, disabled }: SyncManifestProps) {
               })
             );
           })
-          .catch((reason) => console.log(reason));
+          .catch((reason) => console.error(reason));
       }}
     >
       {`Sync Manifest `}

--- a/client/src/features/manifest/MtnList.tsx
+++ b/client/src/features/manifest/MtnList.tsx
@@ -38,7 +38,7 @@ function MtnList(): ReactElement {
             <h2>{siteId}</h2>
           </Col>
           <Col className="d-flex justify-content-end">
-            <SyncManifestBtn siteId={siteId ? siteId : ''} />
+            <SyncManifestBtn siteId={siteId} disabled={!siteId} />
             <Button variant="success" onClick={() => navigate('./new')}>
               New
             </Button>

--- a/client/src/features/profile/RcraProfile/RcraProfile.tsx
+++ b/client/src/features/profile/RcraProfile/RcraProfile.tsx
@@ -153,10 +153,7 @@ function RcraProfile({ profile }: ProfileViewProps) {
           className="mx-2"
           variant="primary"
           onClick={() =>
-            htApi
-              .get(`trak/profile/${profile.user}/sync`)
-              .then((r) => console.log('ToDo: replace this\n', r))
-              .catch((r) => console.error(r))
+            htApi.get(`trak/profile/${profile.user}/sync`).catch((r) => console.error(r))
           }
         >
           Sync Site Permissions

--- a/client/src/test-utils/fixtures/index.ts
+++ b/client/src/test-utils/fixtures/index.ts
@@ -1,8 +1,15 @@
 import {
   createMockHandler,
   createMockTransporter,
+  createMockMTNHandler,
   createMockSite,
 } from 'test-utils/fixtures/mockHandler';
 import { createMockManifest } from 'test-utils/fixtures/mockManifest';
 
-export { createMockHandler, createMockTransporter, createMockManifest, createMockSite };
+export {
+  createMockHandler,
+  createMockMTNHandler,
+  createMockTransporter,
+  createMockManifest,
+  createMockSite,
+};

--- a/client/src/test-utils/fixtures/mockHandler.ts
+++ b/client/src/test-utils/fixtures/mockHandler.ts
@@ -5,7 +5,6 @@ import { Handler, ManifestHandler, Site, Transporter } from 'types/handler';
  */
 const DEFAULT_HANDLER: ManifestHandler = {
   epaSiteId: 'testSiteIdNumber',
-  siteType: 'Generator',
   name: 'TEST TRANSPORTER 2 OF VA',
   siteAddress: {
     streetNumber: '123',
@@ -60,6 +59,14 @@ const DEFAULT_HANDLER: ManifestHandler = {
 export function createMockHandler(overWrites?: Partial<Handler>): Handler {
   return {
     ...DEFAULT_HANDLER,
+    ...overWrites,
+  };
+}
+
+export function createMockMTNHandler(overWrites?: Partial<ManifestHandler>): ManifestHandler {
+  return {
+    ...createMockHandler(),
+    electronicSignaturesInfo: [],
     ...overWrites,
   };
 }

--- a/client/src/test-utils/fixtures/mockManifest.ts
+++ b/client/src/test-utils/fixtures/mockManifest.ts
@@ -1,5 +1,5 @@
 import { Manifest } from 'types/manifest';
-import { createMockHandler, createMockTransporter } from 'test-utils/fixtures/mockHandler';
+import { createMockMTNHandler, createMockTransporter } from 'test-utils/fixtures/mockHandler';
 import { createMockWaste } from 'test-utils/fixtures/mockWaste';
 
 export const DEFAULT_MANIFEST: Manifest = {
@@ -10,9 +10,12 @@ export const DEFAULT_MANIFEST: Manifest = {
   locked: false,
   containsPreviousRejectOrResidue: false,
   potentialShipDate: '2022-12-14T12:50:12+0000',
-  generator: createMockHandler(),
-  transporters: [{ ...createMockTransporter() }, { ...createMockTransporter({ order: 2 }) }],
-  designatedFacility: createMockHandler(),
+  generator: createMockMTNHandler({ epaSiteId: 'VATESTGEN001' }),
+  transporters: [
+    { ...createMockTransporter({ order: 1 }) },
+    { ...createMockTransporter({ order: 2 }) },
+  ],
+  designatedFacility: createMockMTNHandler({ epaSiteId: 'VATEST001' }),
   wastes: [{ ...createMockWaste({ lineNumber: 1 }) }, { ...createMockWaste({ lineNumber: 2 }) }],
 };
 

--- a/client/src/types/handler/handler.ts
+++ b/client/src/types/handler/handler.ts
@@ -64,7 +64,6 @@ export interface PaperSignature {
 export interface ManifestHandler extends Handler {
   paperSignatureInfo?: PaperSignature;
   electronicSignaturesInfo?: Array<ElectronicSignature>;
-  siteType?: 'Generator' | 'Broken' | 'Transporter' | 'Tsdf';
   /**
    * Property on by back end to signify whether the handler has signed
    */

--- a/client/src/types/manifest/signatures.ts
+++ b/client/src/types/manifest/signatures.ts
@@ -1,3 +1,5 @@
+import { ManifestHandler } from 'types/handler';
+
 /**
  * The EPA Quicker Sign schema
  */
@@ -16,4 +18,9 @@ export interface QuickerSignature {
 export interface QuickerSignForm {
   printedSignatureName: string;
   printedSignatureDate: string;
+}
+
+export interface QuickerSignData {
+  handler: ManifestHandler | undefined;
+  siteType: 'Generator' | 'Transporter' | 'Tsdf';
 }

--- a/client/src/types/manifest/signatures.ts
+++ b/client/src/types/manifest/signatures.ts
@@ -3,7 +3,7 @@
  */
 export interface QuickerSignature {
   siteId: string;
-  siteType: 'Transporter' | 'Generator' | 'Tsdf';
+  siteType: 'Transporter' | 'Generator' | 'Tsdf' | 'Broker';
   transporterOrder?: number;
   printedSignatureName: string;
   printedSignatureDate: string;

--- a/server/apps/trak/models/handler_model.py
+++ b/server/apps/trak/models/handler_model.py
@@ -231,7 +231,9 @@ class ManifestHandler(TrakBaseModel):
     @property
     def signed(self) -> bool:
         """Returns True if one of the signature types is present"""
-        e_signature_exists = ESignature.objects.filter(manifest_handler=self).exists()
+        e_signature_exists = ESignature.objects.filter(
+            manifest_handler=self, sign_date__isnull=False
+        ).exists()
         paper_signature_exists = self.paper_signature is not None
         return paper_signature_exists or e_signature_exists
 


### PR DESCRIPTION
## Description

This PR adds the ability to submit electronic (Quicker Sign) signatures from the (react) client. This also adjust the gating for the `SyncManifestBtn`, `RcraApiUserBtn` and the new `QuickerSignModalBtn`. The Quicker Sign Form has default values of the user's username and the current date. (however, we may consider remove the default username since we want the signature to be an intention action. 

We also need to add front end validation for the QuickerSignForm. 

The following general rules apply for the above buttons
1. for `SyncManifestBtn` there must be a siteId to sync to
2. for `RcraApiUserBtn` the user's profile must have `apiUser` set to true in the redux store (in thier RcraProfile)
3. for `QuickerSignModalBtn` the manifest must be in either
    - `"Scheduled"`
    - `"InTransit" `
    - `"ReadyForSignature"`
4.for `QuickerSignModalBtn` In addition, the `signed` property for the relevant `ManifestHandler` must be false
5. For all, if the `disabled` prop is passed as `true` then the button should be disabled.

This PR fixes the above gating criteria for when the button can be used and also fixes the serializer `signed` property on the `ManifestHandlerSerializer`.

## Issue ticket number and link
relevant to #412 
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->

## Checklist

<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Other Stuff
