### PR TITLE
temporary AllowAny on EpaProfileView until bigger fix

### DIFF
--- a/server/apps/sites/views/profile_views.py
+++ b/server/apps/sites/views/profile_views.py
@@ -25,6 +25,7 @@ class EpaProfileView(RetrieveUpdateAPIView):
     response = Response
     lookup_field = "user__username"
     lookup_url_kwarg = "user"
+    permission_classes = [permissions.AllowAny]  # temporary, remove me
 
 
 class SyncProfileView(GenericAPIView):


### PR DESCRIPTION
## Description

Temporarily add AllowAny permission to EpaProfileView until we can come back and fix this with a legit design pattern.

we do this instead of using the htApi service in the user profile page as that gives us some warnings. in the future, we will likely consolidate the haztrak services layer into redux. 

## Issue ticket number and link

<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->

## Checklist

<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Other Stuff
