### PR TITLE
Potential ship date validation

### DIFF
--- a/client/src/components/Ht/HtTooltip/HtTooltip.tsx
+++ b/client/src/components/Ht/HtTooltip/HtTooltip.tsx
@@ -1,3 +1,5 @@
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { TooltipProps } from 'react-bootstrap';
 import { ReactElement } from 'react';
@@ -26,4 +28,22 @@ function HtTooltip(props: HtToolTipProps): ReactElement {
   );
 }
 
+interface InfoTooltipProps {
+  message: string;
+}
+
+/**
+ * Returns an info icon with a tooltip message
+ * that explains that this Field is set by EPA's RCRAInfo.
+ * @constructor
+ */
+function InfoIconTooltip({ message }: InfoTooltipProps) {
+  return (
+    <HtTooltip text={message}>
+      <FontAwesomeIcon icon={faInfoCircle} size={'1x'} className={'pb-1 text-muted'} />
+    </HtTooltip>
+  );
+}
+
 export default HtTooltip;
+export { InfoIconTooltip };

--- a/client/src/components/Ht/HtTooltip/index.ts
+++ b/client/src/components/Ht/HtTooltip/index.ts
@@ -1,3 +1,4 @@
-import HtTooltip from 'components/Ht/HtTooltip/HtTooltip';
+import HtTooltip, { InfoIconTooltip } from 'components/Ht/HtTooltip/HtTooltip';
 
 export default HtTooltip;
+export { InfoIconTooltip };

--- a/client/src/components/ManifestForm/ManifestForm.spec.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.spec.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import { cleanup, renderWithProviders } from 'test-utils';
 import ManifestForm from './ManifestForm';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 afterEach(() => {
   cleanup();
@@ -36,15 +36,13 @@ describe('ManifestForm', () => {
     // ToDo: to test when readOnly={true}, we need manifestData to pass as prop
   });
   test('potential ship date cannot be in past', async () => {
-    // Arrange
     renderWithProviders(<ManifestForm readOnly={false} />);
     const potentialShipDateInput = screen.getByLabelText(/potential ship date/i);
     fireEvent.change(potentialShipDateInput, { target: { value: '2021-04-21' } });
     const saveBtn = screen.getByRole('button', { name: /save/i });
-    // Act
     fireEvent.click(saveBtn);
-    // Assert
-    const newShipDate = await screen.findByLabelText(/potential ship date/i);
-    expect(newShipDate).toHaveClass('is-invalid');
+    await waitFor(() => {
+      expect(potentialShipDateInput).toHaveClass('is-invalid');
+    });
   });
 });

--- a/client/src/components/ManifestForm/ManifestForm.spec.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.spec.tsx
@@ -32,16 +32,19 @@ describe('ManifestForm', () => {
     fireEvent.click(addTsdfBtn);
     expect(screen.getByText(/Add Designated Facility/i)).toBeInTheDocument();
   });
-  test('usable cancel save buttons editable', async () => {
-    renderWithProviders(<ManifestForm readOnly={false} />);
-    const cancelBtn = screen.getByText(/Cancel/i);
-    const saveBtn = screen.getByText(/Save/i);
-    const editBtn = screen.getByText(/Edit/i);
-    expect(cancelBtn).not.toHaveAttribute('disabled');
-    expect(saveBtn).not.toHaveAttribute('disabled');
-    expect(editBtn).toHaveAttribute('disabled');
-  });
   test('only has "edit manifest" button when readonly', async () => {
     // ToDo: to test when readOnly={true}, we need manifestData to pass as prop
+  });
+  test('potential ship date cannot be in past', async () => {
+    // Arrange
+    renderWithProviders(<ManifestForm readOnly={false} />);
+    const potentialShipDateInput = screen.getByLabelText(/potential ship date/i);
+    fireEvent.change(potentialShipDateInput, { target: { value: '2021-04-21' } });
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    // Act
+    fireEvent.click(saveBtn);
+    // Assert
+    const newShipDate = await screen.findByLabelText(/potential ship date/i);
+    expect(newShipDate).toHaveClass('is-invalid');
   });
 });

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -6,6 +6,7 @@ import AdditionalInfoForm from 'components/ManifestForm/AdditionalInfo';
 import ContactForm from 'components/ManifestForm/ContactForm';
 import { AddTransporter, TransporterTable } from 'components/ManifestForm/Transporter';
 import { WasteLineTable } from 'components/ManifestForm/WasteLine/WasteLineTable/WasteLineTable';
+import { d } from 'msw/lib/glossary-de6278a9';
 import React, { useEffect, useState } from 'react';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 import { FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
@@ -33,7 +34,7 @@ interface ManifestFormProps {
  * @constructor
  */
 function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps) {
-  console.log('initial pot. ship date', manifestData?.potentialShipDate);
+  // console.log('initial pot. ship date', manifestData?.potentialShipDate);
 
   // Top level ManifestForm methods and objects
   const manifestMethods = useForm<Manifest>({
@@ -49,6 +50,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
   const navigate = useNavigate();
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
     console.log('Manifest Submitted', data);
+    console.log('submit pot ship date: ', data.potentialShipDate);
   };
 
   // Generator controls
@@ -242,7 +244,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                 </Col>
                 <Col>
                   <HtForm.Group>
-                    <HtForm.Label htmlFor="potentialShipDate">Potential Shipped Date</HtForm.Label>
+                    <HtForm.Label htmlFor="potentialShipDate">Potential Ship Date</HtForm.Label>
                     <Form.Control
                       id="potentialShipDate"
                       disabled={readOnly}

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -18,6 +18,7 @@ import AddTsdf from './Tsdf';
 import AddWasteLine from './WasteLine';
 import { QuickerSignModal, QuickerSignModalBtn } from 'components/QuickerSign';
 import { manifestSchema, Manifest, HandlerType } from './manifestSchema';
+import { InfoIconTooltip } from 'components/Ht/HtTooltip';
 
 interface ManifestFormProps {
   readOnly?: boolean;
@@ -139,6 +140,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                         <option value="NotAssigned">Draft</option>
                         <option value="Pending">Pending</option>
                         <option value="Scheduled">Scheduled</option>
+                        <option value="ReadyForSignature">Ready for Signature</option>
                       </HtForm.Select>
                     )}
                   </HtForm.Group>
@@ -167,9 +169,13 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
               <Row>
                 <Col>
                   <HtForm.Group>
-                    <HtForm.Label htmlFor="createdDate">Created Date</HtForm.Label>
+                    <HtForm.Label htmlFor="createdDate">
+                      {'Created Date '}
+                      <InfoIconTooltip message={'This field is managed by EPA'} />
+                    </HtForm.Label>
                     <Form.Control
                       id="createdDate"
+                      plaintext
                       disabled
                       type="date"
                       {...manifestMethods.register('createdDate', { valueAsDate: true })}
@@ -180,9 +186,13 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                 </Col>
                 <Col>
                   <HtForm.Group>
-                    <HtForm.Label htmlFor="updatedDate">Last Update Date</HtForm.Label>
+                    <HtForm.Label htmlFor="updatedDate">
+                      {'Last Update Date '}
+                      <InfoIconTooltip message={'This field is managed by EPA'} />
+                    </HtForm.Label>
                     <Form.Control
                       id="updatedDate"
+                      plaintext
                       disabled={readOnly}
                       type="date"
                       {...manifestMethods.register('updatedDate', { valueAsDate: true })}

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -33,6 +33,8 @@ interface ManifestFormProps {
  * @constructor
  */
 function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps) {
+  console.log('initial pot. ship date', manifestData?.potentialShipDate);
+
   // Top level ManifestForm methods and objects
   const manifestMethods = useForm<Manifest>({
     values: manifestData,
@@ -44,11 +46,11 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
   const isDraft = !manifestData?.manifestTrackingNumber;
   // On load, focus the generator EPA ID.
   useEffect(() => manifestMethods.setFocus('generator.epaSiteId'), []);
-  // const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
-    console.log(data);
+    console.log('Manifest Submitted', data);
   };
+
   // Generator controls
   const generator: Handler = manifestMethods.getValues('generator');
 
@@ -178,7 +180,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       plaintext
                       disabled
                       type="date"
-                      {...manifestMethods.register('createdDate', { valueAsDate: true })}
+                      {...manifestMethods.register('createdDate')}
                       className={errors.createdDate && 'is-invalid'}
                     />
                     <div className="invalid-feedback">{errors.createdDate?.message}</div>
@@ -195,7 +197,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       plaintext
                       disabled={readOnly}
                       type="date"
-                      {...manifestMethods.register('updatedDate', { valueAsDate: true })}
+                      {...manifestMethods.register('updatedDate')}
                       className={errors.updatedDate && 'is-invalid'}
                     />
                     <div className="invalid-feedback">{errors.updatedDate?.message}</div>
@@ -211,7 +213,9 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       {...manifestMethods.register('shippedDate', { valueAsDate: true })}
                       className={errors.shippedDate && 'is-invalid'}
                     />
-                    <div className="invalid-feedback">{errors.shippedDate?.message}</div>
+                    <div className="invalid-feedback">
+                      {errors.shippedDate?.message?.toString()}
+                    </div>
                   </HtForm.Group>
                 </Col>
               </Row>
@@ -243,7 +247,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       id="potentialShipDate"
                       disabled={readOnly}
                       type="date"
-                      {...manifestMethods.register('potentialShipDate', { valueAsDate: true })}
+                      {...manifestMethods.register('potentialShipDate')}
                       className={errors.potentialShipDate && 'is-invalid'}
                     />
                     <div className="invalid-feedback">{errors.potentialShipDate?.message}</div>

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -6,7 +6,6 @@ import AdditionalInfoForm from 'components/ManifestForm/AdditionalInfo';
 import ContactForm from 'components/ManifestForm/ContactForm';
 import { AddTransporter, TransporterTable } from 'components/ManifestForm/Transporter';
 import { WasteLineTable } from 'components/ManifestForm/WasteLine/WasteLineTable/WasteLineTable';
-import { d } from 'msw/lib/glossary-de6278a9';
 import React, { useEffect, useState } from 'react';
 import { Button, Col, Form, Row } from 'react-bootstrap';
 import { FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';

--- a/client/src/components/ManifestForm/manifestSchema.ts
+++ b/client/src/components/ManifestForm/manifestSchema.ts
@@ -1,35 +1,58 @@
 import { rcraSite } from 'types/site/sites';
 import { z } from 'zod';
 
-export const manifestSchema = z.object({
-  manifestTrackingNumber: z.string().optional(),
-  createdDate: z.date().optional(),
-  updatedDate: z.date().optional(),
-  shippedDate: z.date().optional(),
-  import: z.boolean().optional(),
-  rejection: z.boolean().optional(),
-  potentialShipDate: z.date().optional(),
-  status: z.enum([
-    'NotAssigned',
-    'Pending',
-    'Scheduled',
-    'InTransit',
-    'ReadyForSignature',
-    'Signed',
-    'Corrected',
-    'UnderCorrection',
-    'MtnValidationFailed',
-  ]),
-  /**
-   * Whether the manifest is publicly available through EPA
-   */
-  isPublic: z.boolean().optional(),
-  generator: z.any().optional(),
-  transporters: z.array(z.any()),
-  wastes: z.array(z.any()),
-  designatedFacility: z.any().optional(),
-  submissionType: z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image']),
-});
+export const manifestSchema = z
+  .object({
+    manifestTrackingNumber: z.string().optional(),
+    createdDate: z.date().optional(),
+    updatedDate: z.string(),
+    shippedDate: z.any(),
+    import: z.boolean().optional(),
+    rejection: z.boolean().optional(),
+    potentialShipDate: z
+      .string()
+      .optional()
+      .transform((val) => {
+        if (val === '' || val === undefined) {
+          // If empty string or undefined, return undefined
+          return undefined;
+        } else {
+          return new Date(val).toISOString();
+        }
+      }),
+    status: z.enum([
+      'NotAssigned',
+      'Pending',
+      'Scheduled',
+      'InTransit',
+      'ReadyForSignature',
+      'Signed',
+      'Corrected',
+      'UnderCorrection',
+      'MtnValidationFailed',
+    ]),
+    /**
+     * Whether the manifest is publicly available through EPA
+     */
+    isPublic: z.boolean().optional(),
+    generator: z.any().optional(),
+    transporters: z.array(z.any()),
+    wastes: z.array(z.any()),
+    designatedFacility: z.any().optional(),
+    submissionType: z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image']),
+  })
+  .refine(
+    (manifest) => {
+      console.log('object refine');
+      if (manifest.status === 'Pending' || manifest.status === 'NotAssigned') {
+        if (manifest.potentialShipDate && new Date(manifest.potentialShipDate) < new Date()) {
+          return false;
+        }
+      }
+      return true;
+    },
+    { path: ['potentialShipDate'], message: 'Date must be after today' }
+  );
 
 export type Manifest = z.infer<typeof manifestSchema>;
 /**

--- a/client/src/components/ManifestForm/manifestSchema.ts
+++ b/client/src/components/ManifestForm/manifestSchema.ts
@@ -43,7 +43,6 @@ export const manifestSchema = z
   })
   .refine(
     (manifest) => {
-      console.log('object refine');
       if (manifest.status === 'Pending' || manifest.status === 'NotAssigned') {
         if (manifest.potentialShipDate && new Date(manifest.potentialShipDate) < new Date()) {
           return false;

--- a/server/apps/sites/views/site_views.py
+++ b/server/apps/sites/views/site_views.py
@@ -138,18 +138,19 @@ class RcraSiteSearchView(ListAPIView):
         name_param = self.request.query_params.get("siteName")
         site_type_param: str = self.request.query_params.get("siteType")
         if epa_id_param is not None:
-            queryset = queryset.filter(epa_id__contains=epa_id_param)
+            queryset = queryset.filter(epa_id__icontains=epa_id_param)
         if name_param is not None:
-            queryset = queryset.filter(name__contains=name_param)
+            queryset = queryset.filter(name__icontains=name_param)
         if site_type_param is not None:
             match site_type_param.lower():
                 case "transporter":
                     site_type = RcraSiteType.TRANSPORTER.label
-                case "tsdf":
+                case "designatedfacility":
                     site_type = RcraSiteType.TSDF.label
                 case "generator":
                     site_type = RcraSiteType.GENERATOR.label
                 case _:
-                    site_type = RcraSiteType.TSDF
+                    logger.warning("siteType query parameter not recognized")
+                    site_type = RcraSiteType.GENERATOR.label
             queryset = queryset.filter(site_type=site_type)
         return queryset


### PR DESCRIPTION
## Description

Adds Manifest Schema validation logic for the manifest potential ship date. This is not the highest priority field but was an easy one to go thru the motions on to get the hang of using the [zod library](https://zod.dev/). A new test in the ManifestForm test suite is included.  

This PR also includes a fix to the handler search endpoint (RcraSiteSearchView), and also adds a InfoIconTooltip component for quickly adding a small info circle icon that will dispaly a help message when hovered over.

## Issue ticket number and link

Does not directly closes a ticket
related to #106
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->

## Checklist

<!-- We're so happy your contributing, before we do, there are some things we would like to know before merging your fabulous changes. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Other Stuff
