### PR TITLE
Rcra date field bugs

### DIFF
--- a/client/src/components/ManifestForm/ManifestForm.spec.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.spec.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { cleanup, renderWithProviders } from 'test-utils';
 import ManifestForm from './ManifestForm';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { createMockManifest } from 'test-utils/fixtures';
 
 afterEach(() => {
   cleanup();
@@ -33,7 +34,7 @@ describe('ManifestForm', () => {
     expect(screen.getByText(/Add Designated Facility/i)).toBeInTheDocument();
   });
   test('only has "edit manifest" button when readonly', async () => {
-    // ToDo: to test when readOnly={true}, we need manifestData to pass as prop
+    // ToDo: to test when readOnly={true}, we need manifestData as prop
   });
   test('potential ship date cannot be in past', async () => {
     renderWithProviders(<ManifestForm readOnly={false} />);
@@ -44,5 +45,19 @@ describe('ManifestForm', () => {
     await waitFor(() => {
       expect(potentialShipDateInput).toHaveClass('is-invalid');
     });
+  });
+  test('displays e-Manifest managed dates', async () => {
+    const manifestDate = new Date();
+    const expectedDateValue = manifestDate.toISOString().slice(0, 10);
+    const myManifest = createMockManifest({
+      status: 'InTransit',
+      createdDate: manifestDate.toISOString(),
+      updatedDate: manifestDate.toISOString(),
+      shippedDate: manifestDate.toISOString(),
+    });
+    renderWithProviders(<ManifestForm manifestData={myManifest} readOnly={false} />);
+    expect(screen.getByLabelText(/Created Date/i)).toHaveValue(expectedDateValue);
+    expect(screen.getByLabelText(/Last Update Date/i)).toHaveValue(expectedDateValue);
+    expect(screen.getByLabelText(/Shipped Date/i)).toHaveValue(expectedDateValue);
   });
 });

--- a/client/src/components/ManifestForm/ManifestForm.tsx
+++ b/client/src/components/ManifestForm/ManifestForm.tsx
@@ -181,6 +181,7 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                       plaintext
                       disabled
                       type="date"
+                      value={manifestData?.createdDate?.slice(0, 10)}
                       {...manifestMethods.register('createdDate')}
                       className={errors.createdDate && 'is-invalid'}
                     />
@@ -196,8 +197,9 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                     <Form.Control
                       id="updatedDate"
                       plaintext
-                      disabled={readOnly}
+                      disabled
                       type="date"
+                      value={manifestData?.updatedDate?.slice(0, 10)}
                       {...manifestMethods.register('updatedDate')}
                       className={errors.updatedDate && 'is-invalid'}
                     />
@@ -206,12 +208,17 @@ function ManifestForm({ readOnly, manifestData, siteId, mtn }: ManifestFormProps
                 </Col>
                 <Col>
                   <HtForm.Group>
-                    <HtForm.Label htmlFor="shippedDate">Shipped Date</HtForm.Label>
+                    <HtForm.Label htmlFor="shippedDate">
+                      {'Shipped Date '}
+                      <InfoIconTooltip message={'This field is managed by EPA'} />
+                    </HtForm.Label>
                     <Form.Control
                       id="shippedDate"
-                      disabled={readOnly}
+                      disabled
+                      plaintext
                       type="date"
-                      {...manifestMethods.register('shippedDate', { valueAsDate: true })}
+                      value={manifestData?.shippedDate?.slice(0, 10)}
+                      {...manifestMethods.register('shippedDate')}
                       className={errors.shippedDate && 'is-invalid'}
                     />
                     <div className="invalid-feedback">

--- a/client/src/components/ManifestForm/manifestSchema.ts
+++ b/client/src/components/ManifestForm/manifestSchema.ts
@@ -4,9 +4,21 @@ import { z } from 'zod';
 export const manifestSchema = z
   .object({
     manifestTrackingNumber: z.string().optional(),
-    createdDate: z.date().optional(),
-    updatedDate: z.string(),
-    shippedDate: z.any(),
+    /**
+     * The date-time the manifest was created in the e-Manifest system.
+     * Managed by EPA's systems.
+     */
+    createdDate: z.string().optional(),
+    /**
+     * The last date-time manifest was updated in the e-Manifest system.
+     * Managed by EPA's systems.
+     */
+    updatedDate: z.string().optional(),
+    /**
+     * The date-time the hazardous waste shipment departed (was signed by) the generator.
+     * Managed by EPA's systems, but not present on pre-shipment manifests.
+     */
+    shippedDate: z.string().optional(),
     import: z.boolean().optional(),
     rejection: z.boolean().optional(),
     potentialShipDate: z
@@ -42,6 +54,7 @@ export const manifestSchema = z
     submissionType: z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image']),
   })
   .refine(
+    // Check potential ship date is greater than today if the manifest is still in a pre-shipment phase
     (manifest) => {
       if (manifest.status === 'Pending' || manifest.status === 'NotAssigned') {
         if (manifest.potentialShipDate && new Date(manifest.potentialShipDate) < new Date()) {

--- a/client/src/test-utils/fixtures/mockManifest.ts
+++ b/client/src/test-utils/fixtures/mockManifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from 'types/manifest';
+import { Manifest } from 'components/ManifestForm/manifestSchema';
 import { createMockMTNHandler, createMockTransporter } from 'test-utils/fixtures/mockHandler';
 import { createMockWaste } from 'test-utils/fixtures/mockWaste';
 
@@ -7,9 +7,10 @@ export const DEFAULT_MANIFEST: Manifest = {
   import: false,
   status: 'NotAssigned',
   rejection: false,
-  locked: false,
-  containsPreviousRejectOrResidue: false,
+  // locked: false,
+  // containsPreviousRejectOrResidue: false,
   potentialShipDate: '2022-12-14T12:50:12+0000',
+  submissionType: 'FullElectronic',
   generator: createMockMTNHandler({ epaSiteId: 'VATESTGEN001' }),
   transporters: [
     { ...createMockTransporter({ order: 1 }) },


### PR DESCRIPTION
## Description

This PR fixes a bug where dates managed by RCRAInfo/e-Manifest, such as `createdDate`, `updatedDate`, and `shippedDate` where not being displayed in the manifest form. A regression test is added. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->
relevant to #106 but closes no tickets.

## Checklist
<!-- We're happy your contributing! Before we do, answer these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
