### PR TITLE
ManifestForm status validation/logic and SubmissionType logic

### DIFF
--- a/client/src/components/ManifestForm/manifestSchema.ts
+++ b/client/src/components/ManifestForm/manifestSchema.ts
@@ -64,7 +64,11 @@ export const manifestSchema = z
       return true;
     },
     { path: ['potentialShipDate'], message: 'Date must be after today' }
-  );
+  )
+  .refine((manifest) => {
+    // ToDo Validate that if submission Type is FullElectronic, generator.canEsign is true
+    return true;
+  });
 
 export type Manifest = z.infer<typeof manifestSchema>;
 /**

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -97,8 +97,8 @@ services:
       interval: 3s
       timeout: 3s
       retries: 5
-  #    volumes:
-  #      - development:/var/lib/postgresql/data
+    volumes:
+      - development:/var/lib/postgresql/data
 
   client:
     container_name: ht_client


### PR DESCRIPTION
## Description

This PR adds some logic to the ManifestForm as to whether the fields can be edited. Now, once the manifest has reached a `Scheduled` status neither of the fields can be edited. It also adds the rest of the remaining options to both of these select fields (as hidden choices which we use to display the current status and submission type but do not allow them to be edited once they reach the point in the shipment life cycle that they are managed by the EPA RCRAInfo system).

This PR also re-adds a named volume back to the docker compose file.

This PR also adds initial default values for the `ManifestForm`

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->
relevant to #443 
closes #439 

## Checklist
<!-- We're happy your contributing! Before we do, answer these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
