### PR TITLE
Reset error state

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,13 @@
 
 
 ## Issue ticket number and link
-<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->
+<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
+https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+ -->
 
 
 ## Checklist
-<!-- We're happy your contributing! Before we do, answer these questions where applicable. -->
+<!-- We're happy your contributing! Help us by answering these questions where applicable. -->
 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { Alert, Col, Container, Row } from 'react-bootstrap';
+import { Alert, Button, Col, Container, Row } from 'react-bootstrap';
 
 interface Props {
   children?: ReactNode;
@@ -43,6 +43,11 @@ class ErrorBoundary extends Component<Props, State> {
                 {`${this.state.error}`}
               </Alert>
             </Row>
+            <div className="mx-1 d-flex flex-row-reverse">
+              <Button variant="danger" onClick={() => this.setState({ hasError: false })}>
+                Go back
+              </Button>
+            </div>
           </Col>
         </Container>
       );


### PR DESCRIPTION
## Description

This PR adds a button to the `ErrorBoundary` component that resets the `hasError` state. It does not navigate back as described in #342 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123) -->
closes #342 

## Checklist
<!-- We're happy your contributing! Before we do, answer these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
