### PR TITLE
Emergency phone field

### DIFF
--- a/.idea/runConfigurations/Test_All.xml
+++ b/.idea/runConfigurations/Test_All.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Test All" type="CompoundRunConfigurationType">
     <toRun name="PyTest" type="tests" />
-    <toRun name="Vitest" type="JavaScriptTestRunnerVitest" />
+    <toRun name="Vitest Run" type="JavaScriptTestRunnerVitest" />
     <method v="2" />
   </configuration>
 </component>

--- a/client/src/components/Manifest/Address/AddressForm.tsx
+++ b/client/src/components/Manifest/Address/AddressForm.tsx
@@ -46,7 +46,7 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
   return (
     <>
       <Row className="mb-2">
-        <Col>
+        <Col xs={3}>
           <HtForm.Group>
             <HtForm.Label htmlFor="addressStreetNumber">Street Number</HtForm.Label>
             <Form.Control
@@ -59,7 +59,7 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
             />
           </HtForm.Group>
         </Col>
-        <Col>
+        <Col xs={5}>
           <HtForm.Group>
             <HtForm.Label htmlFor="addressStreetName">Street Name</HtForm.Label>
             <Form.Control
@@ -128,7 +128,7 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
             />
           </HtForm.Group>
         </Col>
-        <Col>
+        <Col xs={2}>
           <HtForm.Group>
             <HtForm.Label className="mb-0" htmlFor="addressZip">
               Zip

--- a/client/src/components/Manifest/Address/AddressForm.tsx
+++ b/client/src/components/Manifest/Address/AddressForm.tsx
@@ -1,23 +1,15 @@
 import { ErrorMessage } from '@hookform/error-message';
 import { HtForm } from 'components/Ht';
-import { HandlerTypeEnum } from 'components/Manifest/manifestSchema';
+import { Manifest } from 'components/Manifest/manifestSchema';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
 import { Controller, useFormContext } from 'react-hook-form';
 import Select from 'react-select';
-import { z } from 'zod';
 import { CountryCode, StateCode } from './StateSelect';
 
-/**
- * indicates whether an address is the site's physical location or mailing location
- */
-const addressType = z.enum(['siteAddress', 'mailingAddress']);
-
-type AddressType = z.infer<typeof addressType>;
-
 interface Props {
-  addressType: AddressType;
-  handlerType: HandlerTypeEnum;
+  addressType: 'siteAddress' | 'mailingAddress';
+  handlerType: 'generator' | 'designatedFacility';
   readOnly?: boolean;
 }
 
@@ -26,13 +18,29 @@ interface Props {
  * Needs to be used in the context of a FormProvider
  */
 export function AddressForm({ addressType, handlerType, readOnly }: Props) {
-  const namePrefix = `${handlerType}.${addressType}`;
   const {
     getValues,
     control,
     register,
     formState: { errors },
-  } = useFormContext();
+  } = useFormContext<Manifest>();
+
+  // Destructure the handler errors depending on whether this is form for
+  // manifest generator of designated facility for use in the form.
+  let handlerErrors = errors.generator;
+  if (handlerType === 'designatedFacility') {
+    handlerErrors = errors.designatedFacility;
+  }
+
+  // Destructure the handler errors depending on whether this is form for
+  // manifest generator of designated facility for use in the form.
+  let addressErrors = undefined;
+  if (handlerErrors) {
+    addressErrors = handlerErrors.siteAddress;
+    if (addressType === 'mailingAddress') {
+      addressErrors = handlerErrors.mailingAddress;
+    }
+  }
 
   return (
     <>
@@ -46,7 +54,7 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="1234"
-              {...register(`${namePrefix}.streetNumber`)}
+              {...register(`${handlerType}.${addressType}.streetNumber`)}
             />
           </HtForm.Group>
         </Col>
@@ -59,8 +67,10 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="Main St."
-              {...register(`${namePrefix}.address1`)}
+              {...register(`${handlerType}.${addressType}.address1`)}
+              className={addressErrors?.address1 && 'is-invalid'}
             />
+            <div className="invalid-feedback">{addressErrors?.address1?.message}</div>
           </HtForm.Group>
         </Col>
         <Col>
@@ -72,44 +82,32 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="Springfield"
-              {...register(`${namePrefix}.city`)}
+              {...register(`${handlerType}.${addressType}.city`)}
+              className={addressErrors?.city && 'is-invalid'}
             />
+            <div className="invalid-feedback">{addressErrors?.city?.message}</div>
           </HtForm.Group>
         </Col>
-        <ErrorMessage
-          errors={errors}
-          name={`${namePrefix}.address1`}
-          render={({ message }) => <span className="text-danger">{message}</span>}
-        />
-        <ErrorMessage
-          errors={errors}
-          name={`${namePrefix}.streetNumber`}
-          render={({ message }) => <span className="text-danger">{message}</span>}
-        />
-        <ErrorMessage
-          errors={errors}
-          name={`${namePrefix}.city`}
-          render={({ message }) => <span className="text-danger">{message}</span>}
-        />
       </Row>
       <Row className="mb-2">
         <Col>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0" htmlFor={`${namePrefix}State`}>
+            <HtForm.Label className="mb-0" htmlFor={`${handlerType}.${addressType}.State`}>
               State
             </HtForm.Label>
             {readOnly ? (
-              <p className="mt-2">{getValues(`${namePrefix}.state.name`)}</p>
+              <p className="mt-2">{getValues(`${handlerType}.${addressType}.state.name`)}</p>
             ) : (
               <Controller
                 control={control}
-                name={`${namePrefix}.state`}
+                name={`${handlerType}.${addressType}.state`}
                 render={({ field }) => {
                   return (
                     <Select
-                      id={`${namePrefix}State`}
+                      id={`${handlerType}${addressType}State`}
                       {...field}
                       options={StateCode}
+                      // @ts-ignore
                       getOptionLabel={(option) => option.name}
                       getOptionValue={(option) => option.code}
                       openMenuOnFocus={false}
@@ -119,6 +117,11 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
                 }}
               />
             )}
+            <ErrorMessage
+              errors={errors}
+              name={`${handlerType}.${addressType}.state`}
+              render={({ message }) => <span className="text-danger">{message}</span>}
+            />
           </HtForm.Group>
         </Col>
         <Col>
@@ -132,28 +135,31 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="12345"
-              {...register(`${namePrefix}.zip`)}
+              {...register(`${handlerType}.${addressType}.zip`)}
+              className={addressErrors?.zip && 'is-invalid'}
             />
+            <div className="invalid-feedback">{addressErrors?.zip?.message}</div>
           </HtForm.Group>
         </Col>
         <Col>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0" htmlFor={`${namePrefix}Country`}>
+            <HtForm.Label className="mb-0" htmlFor={`${handlerType}.${addressType}Country`}>
               Country
             </HtForm.Label>
             {readOnly ? (
-              <p className="mt-2">{getValues(`${namePrefix}.country.name`)}</p>
+              <p className="mt-2">{getValues(`${handlerType}.${addressType}.country.name`)}</p>
             ) : (
               <Controller
                 control={control}
-                name={`${namePrefix}.country`}
+                name={`${handlerType}.${addressType}.country`}
                 render={({ field }) => {
                   return (
                     <Select
-                      id={`${namePrefix}Country`}
+                      id={`${handlerType}.${addressType}Country`}
                       {...field}
                       defaultValue={CountryCode[0]}
                       options={CountryCode}
+                      // @ts-ignore
                       getOptionLabel={(option) => option.name}
                       getOptionValue={(option) => option.code}
                       openMenuOnFocus={false}
@@ -163,18 +169,13 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
                 }}
               />
             )}
+            <ErrorMessage
+              errors={errors}
+              name={`${handlerType}.${addressType}.country`}
+              render={({ message }) => <span className="text-danger">{message}</span>}
+            />
           </HtForm.Group>
         </Col>
-        <ErrorMessage
-          errors={errors}
-          name={`${namePrefix}.zip`}
-          render={({ message }) => <span className="text-danger">{message}</span>}
-        />
-        <ErrorMessage
-          errors={errors}
-          name={`${namePrefix}.state`}
-          render={({ message }) => <span className="text-danger">{message}</span>}
-        />
       </Row>
     </>
   );

--- a/client/src/components/Manifest/Address/AddressForm.tsx
+++ b/client/src/components/Manifest/Address/AddressForm.tsx
@@ -1,9 +1,10 @@
 import { ErrorMessage } from '@hookform/error-message';
 import { HtForm } from 'components/Ht';
 import { Manifest } from 'components/Manifest/manifestSchema';
+import { RcraAddress } from 'components/RcraSite';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, FieldError, FieldErrorsImpl, Merge, useFormContext } from 'react-hook-form';
 import Select from 'react-select';
 import { CountryCode, StateCode } from './StateSelect';
 
@@ -32,9 +33,9 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
     handlerErrors = errors.designatedFacility;
   }
 
-  // Destructure the handler errors depending on whether this is form for
-  // manifest generator of designated facility for use in the form.
-  let addressErrors = undefined;
+  // Destructure the address errors from handlerErrors depending on whether this is form for
+  // manifest the handler's site address or mailing address.
+  let addressErrors: Merge<FieldError, FieldErrorsImpl<RcraAddress>> | undefined = undefined;
   if (handlerErrors) {
     addressErrors = handlerErrors.siteAddress;
     if (addressType === 'mailingAddress') {
@@ -107,11 +108,14 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
                       id={`${handlerType}${addressType}State`}
                       {...field}
                       options={StateCode}
-                      // @ts-ignore
-                      getOptionLabel={(option) => option.name}
+                      getOptionLabel={(option) => option.name ?? 'error'}
                       getOptionValue={(option) => option.code}
                       openMenuOnFocus={false}
                       isDisabled={readOnly}
+                      classNames={{
+                        control: () =>
+                          `form-control p-0 rounded-2 ${addressErrors?.state && 'border-danger'} `,
+                      }}
                     />
                   );
                 }}
@@ -159,11 +163,16 @@ export function AddressForm({ addressType, handlerType, readOnly }: Props) {
                       {...field}
                       defaultValue={CountryCode[0]}
                       options={CountryCode}
-                      // @ts-ignore
-                      getOptionLabel={(option) => option.name}
+                      getOptionLabel={(option) => option.name ?? 'error'}
                       getOptionValue={(option) => option.code}
                       openMenuOnFocus={false}
                       isDisabled={readOnly}
+                      classNames={{
+                        control: () =>
+                          `form-control p-0 rounded-2 ${
+                            addressErrors?.country && 'border-danger'
+                          } `,
+                      }}
                     />
                   );
                 }}

--- a/client/src/components/Manifest/Contact/ContactForm.spec.tsx
+++ b/client/src/components/Manifest/Contact/ContactForm.spec.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 
 describe('ContactForm', () => {
   test('renders with basic information inputs', () => {
-    renderWithProviders(<ContactForm handlerFormType={'generator'} />);
+    renderWithProviders(<ContactForm handlerType={'generator'} />);
     expect(screen.getByText(/First Name/i)).toBeInTheDocument();
     expect(screen.getByText(/Last Name/i)).toBeInTheDocument();
   });

--- a/client/src/components/Manifest/Contact/ContactForm.tsx
+++ b/client/src/components/Manifest/Contact/ContactForm.tsx
@@ -30,7 +30,7 @@ export function ContactForm({ handlerType, readOnly }: ContactFormProps) {
             />
           </HtForm.Group>
         </Col>
-        <Col>
+        <Col xs={3}>
           <HtForm.Group>
             <HtForm.Label htmlFor={`${namePrefix}MiddleInitial`}>Middle Initial</HtForm.Label>
             <Form.Control

--- a/client/src/components/Manifest/Contact/ContactForm.tsx
+++ b/client/src/components/Manifest/Contact/ContactForm.tsx
@@ -1,3 +1,4 @@
+import { PhoneForm } from 'components/Manifest/Contact/PhoneForm';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Col, Form, Row } from 'react-bootstrap';
@@ -5,12 +6,12 @@ import { Manifest } from 'types/manifest';
 import { HtForm } from 'components/Ht';
 
 interface ContactFormProps {
-  handlerFormType: 'generator' | 'designatedFacility';
+  handlerType: 'generator' | 'designatedFacility';
   readOnly?: boolean;
 }
 
-export function ContactForm({ handlerFormType, readOnly }: ContactFormProps) {
-  const namePrefix = `${handlerFormType}.contact`;
+export function ContactForm({ handlerType, readOnly }: ContactFormProps) {
+  const namePrefix = `${handlerType}.contact`;
   const { register } = useFormContext<Manifest>();
 
   return (
@@ -25,7 +26,7 @@ export function ContactForm({ handlerFormType, readOnly }: ContactFormProps) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="John"
-              {...register(`${handlerFormType}.contact.firstName`)}
+              {...register(`${handlerType}.contact.firstName`)}
             />
           </HtForm.Group>
         </Col>
@@ -38,7 +39,7 @@ export function ContactForm({ handlerFormType, readOnly }: ContactFormProps) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="G"
-              {...register(`${handlerFormType}.contact.middleInitial`)}
+              {...register(`${handlerType}.contact.middleInitial`)}
             />
           </HtForm.Group>
         </Col>
@@ -51,7 +52,7 @@ export function ContactForm({ handlerFormType, readOnly }: ContactFormProps) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="Doe"
-              {...register(`${handlerFormType}.contact.firstName`)}
+              {...register(`${handlerType}.contact.firstName`)}
             />
           </HtForm.Group>
         </Col>
@@ -66,7 +67,7 @@ export function ContactForm({ handlerFormType, readOnly }: ContactFormProps) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="john.doe@haztrak.net"
-              {...register(`${handlerFormType}.contact.email`)}
+              {...register(`${handlerType}.contact.email`)}
             />
           </HtForm.Group>
         </Col>
@@ -79,11 +80,12 @@ export function ContactForm({ handlerFormType, readOnly }: ContactFormProps) {
               plaintext={readOnly}
               readOnly={readOnly}
               placeholder="HazTek LLC."
-              {...register(`${handlerFormType}.contact.companyName`)}
+              {...register(`${handlerType}.contact.companyName`)}
             />
           </HtForm.Group>
         </Col>
       </Row>
+      <PhoneForm handlerType={handlerType} readOnly={readOnly} />
     </>
   );
 }

--- a/client/src/components/Manifest/Contact/PhoneForm.spec.tsx
+++ b/client/src/components/Manifest/Contact/PhoneForm.spec.tsx
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom';
+import { PhoneForm } from 'components/Manifest/Contact';
+import React from 'react';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PhoneForm', () => {
+  test('renders', () => {
+    renderWithProviders(<PhoneForm handlerType={'generator'} />);
+    expect(screen.getByText(/Phone Number/i)).toBeInTheDocument();
+    expect(screen.getByText(/Extension/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Manifest/Contact/PhoneForm.tsx
+++ b/client/src/components/Manifest/Contact/PhoneForm.tsx
@@ -41,7 +41,7 @@ export function PhoneForm({ handlerType, readOnly }: ContactFormProps) {
             <div className="invalid-feedback">{handlerErrors?.emergencyPhone?.number?.message}</div>
           </HtForm.Group>
         </Col>
-        <Col>
+        <Col xs={3}>
           <HtForm.Group>
             <HtForm.Label htmlFor={`${handlerType}Extension`}>Extension</HtForm.Label>
             <Form.Control

--- a/client/src/components/Manifest/Contact/PhoneForm.tsx
+++ b/client/src/components/Manifest/Contact/PhoneForm.tsx
@@ -1,0 +1,69 @@
+import { ErrorMessage } from '@hookform/error-message';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Col, Form, Row } from 'react-bootstrap';
+import { Manifest } from 'types/manifest';
+import { HtForm } from 'components/Ht';
+
+interface ContactFormProps {
+  handlerType: 'generator' | 'designatedFacility';
+  readOnly?: boolean;
+}
+
+export function PhoneForm({ handlerType, readOnly }: ContactFormProps) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<Manifest>();
+
+  // Destructure the handler errors depending on whether this is form for
+  // manifest generator of designated facility for use in the form.
+  let handlerErrors = errors.generator;
+  if (handlerType === 'designatedFacility') {
+    handlerErrors = errors.designatedFacility;
+  }
+
+  return (
+    <>
+      <Row className="mb-2">
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor={`${handlerType}Number`}>Phone Number</HtForm.Label>
+            <Form.Control
+              id={`${handlerType}Number`}
+              type="text"
+              plaintext={readOnly}
+              readOnly={readOnly}
+              placeholder="202-505-5505"
+              {...register(`${handlerType}.emergencyPhone.number`)}
+              className={handlerErrors?.emergencyPhone?.number && 'is-invalid'}
+            />
+            <div className="invalid-feedback">{handlerErrors?.emergencyPhone?.number?.message}</div>
+          </HtForm.Group>
+        </Col>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor={`${handlerType}Extension`}>Extension</HtForm.Label>
+            <Form.Control
+              id={`${handlerType}Extension`}
+              type="text"
+              plaintext={readOnly}
+              readOnly={readOnly}
+              placeholder="345"
+              {...register(`${handlerType}.emergencyPhone.extension`)}
+              className={handlerErrors?.emergencyPhone?.extension && 'is-invalid'}
+            />
+            <div className="invalid-feedback">
+              {handlerErrors?.emergencyPhone?.extension?.message}
+            </div>
+            <ErrorMessage
+              errors={errors}
+              name={`${handlerType}.emergencyPhone.extension`}
+              render={({ message }) => <span className="text-danger">{message}</span>}
+            />
+          </HtForm.Group>
+        </Col>
+      </Row>
+    </>
+  );
+}

--- a/client/src/components/Manifest/Contact/index.ts
+++ b/client/src/components/Manifest/Contact/index.ts
@@ -1,3 +1,4 @@
 import { ContactForm } from './ContactForm';
+import { PhoneForm } from './PhoneForm';
 
-export { ContactForm };
+export { ContactForm, PhoneForm };

--- a/client/src/components/Manifest/Handler/HandlerForm.tsx
+++ b/client/src/components/Manifest/Handler/HandlerForm.tsx
@@ -1,22 +1,17 @@
 import { HtForm } from 'components/Ht';
 import { AddressForm } from 'components/Manifest/Address';
-import { HandlerTypeEnum } from 'components/Manifest/manifestSchema';
 import { ReactElement, useEffect, useState } from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
 import { useFormContext } from 'react-hook-form';
 import { Manifest } from 'types/manifest';
 
 interface HandlerFormProps {
-  handlerType: HandlerTypeEnum;
+  handlerType: 'generator' | 'designatedFacility';
   readOnly?: boolean;
 }
 
 export function HandlerForm({ handlerType, readOnly }: HandlerFormProps): ReactElement {
   const [mailCheck, setMailCheck] = useState(false);
-  if (handlerType !== 'generator') {
-    throw new Error();
-  }
-
   const {
     register,
     getValues,
@@ -41,6 +36,13 @@ export function HandlerForm({ handlerType, readOnly }: HandlerFormProps): ReactE
     watch(`${handlerType}.siteAddress.state`),
   ]);
 
+  // Destructure the handler errors depending on whether this is form for
+  // manifest generator of designated facility for use in the form.
+  let handlerErrors = errors.generator;
+  if (handlerType === 'designatedFacility') {
+    handlerErrors = errors.designatedFacility;
+  }
+
   return (
     <>
       <Row className="mb-2">
@@ -54,9 +56,9 @@ export function HandlerForm({ handlerType, readOnly }: HandlerFormProps): ReactE
               readOnly={readOnly}
               placeholder={'EPA ID number'}
               {...register(`generator.epaSiteId`)}
-              className={errors.generator?.epaSiteId && 'is-invalid'}
+              className={handlerErrors?.epaSiteId && 'is-invalid'}
             />
-            <div className="invalid-feedback">{errors.generator?.epaSiteId?.message}</div>
+            <div className="invalid-feedback">{handlerErrors?.epaSiteId?.message}</div>
           </HtForm.Group>
         </Col>
         <Col className="col-sm-8">
@@ -69,15 +71,17 @@ export function HandlerForm({ handlerType, readOnly }: HandlerFormProps): ReactE
               type="text"
               placeholder={`${handlerType} Name`}
               {...register(`generator.name`)}
-              className={errors.generator?.name && 'is-invalid'}
+              className={handlerErrors?.name && 'is-invalid'}
             />
-            <div className="invalid-feedback">{errors.generator?.name?.message}</div>
+            <div className="invalid-feedback">{handlerErrors?.name?.message}</div>
           </HtForm.Group>
         </Col>
       </Row>
       <AddressForm addressType={'siteAddress'} handlerType={handlerType} readOnly={readOnly} />
       <Row className="mb-2">
         <Col>
+          {/* Check box that indicated whether the mailing address is different from the*/}
+          {/* handler's address*/}
           <HtForm.Check
             defaultChecked={mailCheck}
             onChange={(e) => {

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -312,7 +312,7 @@ export function ManifestForm({
                 <>
                   <RcraSiteDetails handler={generator} />
                   <h4>Emergency Contact Information</h4>
-                  <ContactForm handlerFormType="generator" readOnly={readOnly} />
+                  <ContactForm handlerType="generator" readOnly={readOnly} />
                   <div className="d-flex justify-content-between">
                     {/* Button to bring up the Quicker Sign modal*/}
                     <Col className="text-end">
@@ -329,7 +329,7 @@ export function ManifestForm({
                 <>
                   <HandlerForm handlerType={HandlerType.enum.generator} readOnly={readOnly} />
                   <h4>Emergency Contact Information</h4>
-                  <ContactForm handlerFormType="generator" readOnly={readOnly} />
+                  <ContactForm handlerType="generator" readOnly={readOnly} />
                 </>
               )}
             </HtCard.Body>

--- a/client/src/components/Manifest/index.ts
+++ b/client/src/components/Manifest/index.ts
@@ -1,6 +1,6 @@
 import { ManifestForm } from './ManifestForm';
-import { Manifest } from './manifestSchema';
 import {
+  Manifest,
   Handler,
   HandlerType,
   Signer,

--- a/client/src/components/RcraSite/rcraSiteSchema.ts
+++ b/client/src/components/RcraSite/rcraSiteSchema.ts
@@ -1,14 +1,10 @@
 import { z } from 'zod';
 
 export const rcraPhoneSchema = z.object({
-  number: z.string(),
+  // ToDo validate length and phone format/content separately
+  number: z.string().min(12, 'Phone in {3}-{3}-{4} format Required'),
   extension: z.string().optional(),
 });
-
-/**
- * RCRA Phone schema defined by RCRAInfo including Phone and optional extension
- */
-export type RcraPhone = z.infer<typeof rcraPhoneSchema>;
 
 export const rcraContactSchema = z.object({
   firstName: z.string().optional(),
@@ -19,10 +15,6 @@ export const rcraContactSchema = z.object({
   companyName: z.string().optional(),
 });
 
-/**
- * Contact information for a given handler listed on the hazardous waste manifest
- */
-export type RcraContact = z.infer<typeof rcraContactSchema>;
 /**
  * Locality Schema for EPA's Rcrainfo which contains information on a geographic region (state, country)
  * used for RCRA sites and handlers on a hazardous waste manifest
@@ -113,3 +105,13 @@ export type RcraAddress = z.infer<typeof rcraAddressSchema>;
  * stored by EPA's RCRAInfo
  */
 export type RcraLocality = z.infer<typeof rcraLocalitySchema>;
+
+/**
+ * RCRA Phone schema defined by RCRAInfo including Phone and optional extension
+ */
+export type RcraPhone = z.infer<typeof rcraPhoneSchema>;
+
+/**
+ * Contact information for a given handler listed on the hazardous waste manifest
+ */
+export type RcraContact = z.infer<typeof rcraContactSchema>;

--- a/client/src/components/RcraSite/rcraSiteSchema.ts
+++ b/client/src/components/RcraSite/rcraSiteSchema.ts
@@ -30,7 +30,7 @@ export const rcraLocalitySchema = z.object({
  * Address Schema  information for handlers on a hazardous waste manifest
  */
 export const rcraAddressSchema = z.object({
-  address1: z.string().min(3, { message: 'Address must be at least 3 characters' }),
+  address1: z.string().min(3, { message: 'Required' }),
   address2: z.string().optional(),
   city: z.string().optional(),
   country: rcraLocalitySchema.optional(),
@@ -45,7 +45,7 @@ export const rcraSite = z.object({
    * physical location for a generator, transporter, or TSDF
    * that should be used on documents and forms submitted to EPA and states
    */
-  epaSiteId: z.string().min(4, { message: "EPA ID should be 9 numbers and 3 letters of 'VSQG'" }),
+  epaSiteId: z.string().min(4, { message: "EPA ID should be 9 numbers and 3 letters or 'VSQG'" }),
   mailingAddress: rcraAddressSchema,
   /**
    * Represents the physical address of a facility regulated under RCRA, it should be tied to an EPA ID

--- a/client/src/test-utils/render.tsx
+++ b/client/src/test-utils/render.tsx
@@ -1,7 +1,7 @@
 import { PreloadedState } from '@reduxjs/toolkit';
 import { render, RenderOptions } from '@testing-library/react';
 import React, { PropsWithChildren, ReactElement } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, UseFormProps } from 'react-hook-form';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { AppStore, RootState, setupStore } from 'store';
@@ -9,7 +9,7 @@ import { AppStore, RootState, setupStore } from 'store';
 interface ExtendedRenderOptions extends Omit<RenderOptions, 'queries'> {
   preloadedState?: PreloadedState<RootState>;
   store?: AppStore;
-  defaultValues?: object;
+  useFormProps?: UseFormProps;
 }
 
 /**
@@ -33,13 +33,13 @@ export function renderWithProviders(
   ui: React.ReactElement,
   {
     preloadedState = {}, // an object with partial slices of our redux state
-    defaultValues = {}, // for Forms
+    useFormProps = {},
     store = setupStore(preloadedState), // Automatically create a store instance if no store was passed in
     ...renderOptions // react-testing library function options
   }: ExtendedRenderOptions = {} // default to empty object
 ) {
   function Wrapper({ children }: PropsWithChildren<{}>): ReactElement {
-    const formMethods = useForm({ defaultValues });
+    const formMethods = useForm(useFormProps);
     return (
       <Provider store={store}>
         <BrowserRouter>

--- a/docs/haztrak_book/src/development/contributing.md
+++ b/docs/haztrak_book/src/development/contributing.md
@@ -32,7 +32,7 @@ submitting a PR. we also welcome draft PRs.
 If you're looking to contribute code or documentation, here's the general process...
 
 - Ask to be assigned an [Issues](https://github.com/USEPA/haztrak/issues).
-- Fork this repo to your GitHub account.
+- Fork this repo to your GitHub account (click 'Fork').
 - Clone your fork to your local workstation.
 
 ```shell
@@ -40,7 +40,7 @@ git clone git@github.com/<yourgithubusername>/haztrak.git
 ```
 
 - Install the [pre-commit](https://pre-commit.com/) hooks
-  - Once installed, will lint and format your changes to ensure we have a consistent style
+  - Once installed, will lint and format your changes to ensure we have a consistent style upon every commit.
   - See [pre-commit installation docs](https://pre-commit.com/#installation)
 
 ```shell
@@ -48,15 +48,23 @@ pre-commit install
 ```
 
 - See our documentation on setting up a [local development environment](./local-development.md)
-- If you are adding or changing haztrak's functionality, include new test(s) and
-  make sure the test suite passes.
+- Create a new branch, make and commit your changes
+
+```shell
+git checkout -b "my_awesome_feature"
+```
+
+- If you are adding or changing haztrak's functionality, include a new test and
+  make sure the entire test suite passes.
   - [See our documentation on Testing Haztrak](../design/testing.md)
 - Submit a pull request to [USEPA/haztrak](https://github.com/USEPA/haztrak/pulls)
+  - Your PR should come from a new branch, not the default branch (usually 'main') and please leave "Allow edits from maintainers" checked.
+  - This way, if small edits need to be made, we can still do that.
 
 ## Pull Request Guidelines
 
 Before you submit a pull request, please make sure that your changes align with
-our project goals and vision. Here are some guidelines to follow when submitting a pull request:
+our project goals and vision (create an issue if you're not sure). Here are some guidelines to follow when submitting a pull request:
 
 - Keep your pull requests small and focused.
 - Make sure your code is well-documented and tested.


### PR DESCRIPTION
## Description

This PR creates a new `PhoneForm` in the context of the manifest. It is used to gather user input on a handler's `emergencyPhone` field (is separate from the `contact` object) It is rendered by the `ContactForm` in a a `HandlerForm`. Keeping it as a separate component means we can use it outside the contact form (which we will need to do later) in instances where the handler details are read only but they still need to provide the emergency phone number on a per-manifest basis.

This PR also makes some small non-functional UI adjustments to the Handler form inputs, namely adjusting the width to more closely align with the length of the expected input, and using bootstrap styling in our react-select components.


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->


## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
