### PR TITLE
Filter by status

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -18,7 +18,7 @@ $info: #009999;
 
 // Custom Pagination
 .page-item .page-link {
-  background: none;
+  background: white;
   margin-inline: 0.25rem;
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -16,6 +16,15 @@ $info: #009999;
   left: -0.25rem !important;
 }
 
+// Custom Pagination
+.page-item .page-link {
+  background: none;
+  margin-inline: 0.25rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  border-radius: 50px !important;
+}
+
 .modal-90w {
   width: 90% !important;
   max-width: none !important;

--- a/client/src/components/Ht/HtCard/HtCard.tsx
+++ b/client/src/components/Ht/HtCard/HtCard.tsx
@@ -24,7 +24,7 @@ interface SpinnerProps extends CardProps {
  * </HtCard>
  */
 export function HtCard(props: CardProps): ReactElement {
-  const baseAttributes = `my-3 shadow-lg bg-light rounded px-0 ${
+  const baseAttributes = `my-3 shadow-lg bg-white rounded px-0 ${
     props.className ? props.className : ''
   }`;
   const classAttributes =

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -31,8 +31,6 @@ export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
     maxVisiblePages: 5,
     useEllipsis: true,
   });
-  console.log('paginationRange', paginationRange);
-  console.log('total count', table.getFilteredRowModel().rows.length);
   if (!paginationRange) {
     return null;
   }

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Table } from '@tanstack/react-table';
 import React from 'react';
 import { Button } from 'react-bootstrap';
+import { boolean } from 'zod';
 
 interface HtPageBtnsProps<T> {
   table: Table<T>;
@@ -21,40 +22,54 @@ interface HtPageBtnsProps<T> {
  * @constructor
  */
 export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
+  console.log(table.getPageOptions());
   return (
     <div className="d-flex justify-content-center">
-      <Button
-        variant="outline-secondary"
-        className="p-1 mx-1"
-        onClick={() => table.setPageIndex(0)}
-        disabled={!table.getCanPreviousPage()}
-      >
-        <FontAwesomeIcon icon={faBackwardFast} className="text-primary" />
-      </Button>
-      <Button
-        variant="outline-secondary"
-        className="p-1 mx-1"
-        onClick={() => table.previousPage()}
-        disabled={!table.getCanPreviousPage()}
-      >
-        <FontAwesomeIcon icon={faCaretLeft} className="text-primary" />
-      </Button>
-      <Button
-        variant="outline-secondary"
-        className="p-1 mx-1"
-        onClick={() => table.nextPage()}
-        disabled={!table.getCanNextPage()}
-      >
-        <FontAwesomeIcon icon={faCaretRight} className="text-primary" />
-      </Button>
-      <Button
-        variant="outline-secondary"
-        className="p-1 mx-1"
-        onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-        disabled={!table.getCanNextPage()}
-      >
-        <FontAwesomeIcon icon={faForwardFast} className="text-primary" />
-      </Button>
+      <div className="bg-light rounded-5 px-1">
+        <Button
+          className="bg-transparent border-0 text-primary px-2"
+          onClick={() => table.setPageIndex(0)}
+          disabled={!table.getCanPreviousPage()}
+        >
+          <FontAwesomeIcon icon={faBackwardFast} size={'lg'} className="text-primary" />
+        </Button>
+        <Button
+          className="bg-transparent border-0 text-primary px-2"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          <FontAwesomeIcon icon={faCaretLeft} size={'lg'} className="text-primary" />
+        </Button>
+        {table.getPageOptions().map((pageNumber: number) => {
+          const pageIndex = table.getState().pagination.pageIndex;
+          return (
+            <Button
+              className={
+                pageIndex === pageNumber
+                  ? 'bg-primary rounded-circle mx-1 py-1'
+                  : 'bg-transparent rounded-circle text-primary mx-1 py-1'
+              }
+              onClick={() => table.setPageIndex(pageNumber)}
+            >
+              {pageNumber + 1}
+            </Button>
+          );
+        })}
+        <Button
+          className="bg-transparent border-0 text-primary px-2"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          <FontAwesomeIcon icon={faCaretRight} size={'lg'} className="text-primary" />
+        </Button>
+        <Button
+          className="bg-transparent border-0 text-primary px-2"
+          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+          disabled={!table.getCanNextPage()}
+        >
+          <FontAwesomeIcon icon={faForwardFast} size={'lg'} className="text-primary" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -7,7 +7,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Table } from '@tanstack/react-table';
 import React from 'react';
-import { Button } from 'react-bootstrap';
+import { Button, Pagination } from 'react-bootstrap';
 import { boolean } from 'zod';
 
 interface HtPageBtnsProps<T> {
@@ -22,54 +22,43 @@ interface HtPageBtnsProps<T> {
  * @constructor
  */
 export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
-  console.log(table.getPageOptions());
   return (
-    <div className="d-flex justify-content-center">
-      <div className="bg-light rounded-5 px-1">
-        <Button
-          className="bg-transparent border-0 text-primary px-2"
-          onClick={() => table.setPageIndex(0)}
-          disabled={!table.getCanPreviousPage()}
-        >
-          <FontAwesomeIcon icon={faBackwardFast} size={'lg'} className="text-primary" />
-        </Button>
-        <Button
-          className="bg-transparent border-0 text-primary px-2"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
-        >
-          <FontAwesomeIcon icon={faCaretLeft} size={'lg'} className="text-primary" />
-        </Button>
-        {table.getPageOptions().map((pageNumber: number) => {
-          const pageIndex = table.getState().pagination.pageIndex;
-          return (
-            <Button
-              className={
-                pageIndex === pageNumber
-                  ? 'bg-primary rounded-circle mx-1 py-1'
-                  : 'bg-transparent rounded-circle text-primary mx-1 py-1'
-              }
-              onClick={() => table.setPageIndex(pageNumber)}
-            >
-              {pageNumber + 1}
-            </Button>
-          );
-        })}
-        <Button
-          className="bg-transparent border-0 text-primary px-2"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
-        >
-          <FontAwesomeIcon icon={faCaretRight} size={'lg'} className="text-primary" />
-        </Button>
-        <Button
-          className="bg-transparent border-0 text-primary px-2"
-          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-          disabled={!table.getCanNextPage()}
-        >
-          <FontAwesomeIcon icon={faForwardFast} size={'lg'} className="text-primary" />
-        </Button>
+    <>
+      <div className="d-flex justify-content-center">
+        <Pagination className="bg-light rounded-5 px-1">
+          <Pagination.First
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <FontAwesomeIcon icon={faBackwardFast} size={'lg'} />
+          </Pagination.First>
+          <Pagination.Prev onClick={table.previousPage} disabled={!table.getCanPreviousPage()}>
+            <FontAwesomeIcon icon={faCaretLeft} size={'lg'} />
+          </Pagination.Prev>
+
+          {table.getPageOptions().map((pageNumber: number) => {
+            const pageIndex = table.getState().pagination.pageIndex;
+            return (
+              <Pagination.Item
+                onClick={() => table.setPageIndex(pageNumber)}
+                key={pageNumber}
+                active={pageNumber === pageIndex}
+              >
+                {pageNumber + 1}
+              </Pagination.Item>
+            );
+          })}
+          <Pagination.Next onClick={table.nextPage} disabled={!table.getCanNextPage()}>
+            <FontAwesomeIcon icon={faCaretRight} size={'lg'} />
+          </Pagination.Next>
+          <Pagination.Last
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <FontAwesomeIcon icon={faForwardFast} size={'lg'} />
+          </Pagination.Last>
+        </Pagination>
       </div>
-    </div>
+    </>
   );
 }

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -8,8 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Table } from '@tanstack/react-table';
 import { usePagination } from 'hooks';
 import React from 'react';
-import { Button, Pagination } from 'react-bootstrap';
-import { boolean } from 'zod';
+import { Pagination } from 'react-bootstrap';
 
 interface HtPageBtnsProps<T> {
   table: Table<T>;
@@ -28,7 +27,7 @@ export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
     pageSize: table.getState().pagination.pageSize,
     siblingCount: 1,
     currentPage: table.getState().pagination.pageIndex,
-    maxVisiblePages: 5,
+    maxVisiblePages: 7,
     useEllipsis: true,
   });
   if (!paginationRange) {

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -6,6 +6,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Table } from '@tanstack/react-table';
+import { usePagination } from 'hooks';
 import React from 'react';
 import { Button, Pagination } from 'react-bootstrap';
 import { boolean } from 'zod';
@@ -22,10 +23,22 @@ interface HtPageBtnsProps<T> {
  * @constructor
  */
 export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
+  const paginationRange = usePagination({
+    totalCount: table.getFilteredRowModel().rows.length,
+    pageSize: table.getState().pagination.pageSize,
+    siblingCount: 2,
+    currentPage: table.getState().pagination.pageIndex,
+    maxVisiblePages: 5,
+    useEllipsis: true,
+  });
+  console.log('page index', table.getState().pagination.pageIndex);
+  if (!paginationRange) {
+    return null;
+  }
   return (
     <>
       <div className="d-flex justify-content-center">
-        <Pagination className="bg-light rounded-5 px-1">
+        <Pagination className="bg-light rounded-5 p-1 py-2">
           <Pagination.First
             onClick={() => table.setPageIndex(0)}
             disabled={!table.getCanPreviousPage()}
@@ -36,15 +49,18 @@ export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
             <FontAwesomeIcon icon={faCaretLeft} size={'lg'} />
           </Pagination.Prev>
 
-          {table.getPageOptions().map((pageNumber: number) => {
+          {paginationRange.map((pageNumber) => {
             const pageIndex = table.getState().pagination.pageIndex;
+            if (typeof pageNumber === 'string') {
+              return <Pagination.Ellipsis key={`mtnListPag${pageIndex}`} disabled={true} />;
+            }
             return (
               <Pagination.Item
-                onClick={() => table.setPageIndex(pageNumber)}
-                key={pageNumber}
-                active={pageNumber === pageIndex}
+                onClick={() => table.setPageIndex(pageNumber - 1)}
+                key={pageNumber - 1}
+                active={pageNumber === pageIndex + 1}
               >
-                {pageNumber + 1}
+                {pageNumber}
               </Pagination.Item>
             );
           })}

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -26,12 +26,13 @@ export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
   const paginationRange = usePagination({
     totalCount: table.getFilteredRowModel().rows.length,
     pageSize: table.getState().pagination.pageSize,
-    siblingCount: 2,
+    siblingCount: 1,
     currentPage: table.getState().pagination.pageIndex,
     maxVisiblePages: 5,
     useEllipsis: true,
   });
-  console.log('page index', table.getState().pagination.pageIndex);
+  console.log('paginationRange', paginationRange);
+  console.log('total count', table.getFilteredRowModel().rows.length);
   if (!paginationRange) {
     return null;
   }
@@ -49,15 +50,15 @@ export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
             <FontAwesomeIcon icon={faCaretLeft} size={'lg'} />
           </Pagination.Prev>
 
-          {paginationRange.map((pageNumber) => {
+          {paginationRange.map((pageNumber, index) => {
             const pageIndex = table.getState().pagination.pageIndex;
             if (typeof pageNumber === 'string') {
-              return <Pagination.Ellipsis key={`mtnListPag${pageIndex}`} disabled={true} />;
+              return <Pagination.Ellipsis key={`mtnListPag${index}`} disabled={true} />;
             }
             return (
               <Pagination.Item
                 onClick={() => table.setPageIndex(pageNumber - 1)}
-                key={pageNumber - 1}
+                key={`mtnListPag${index}`}
                 active={pageNumber === pageIndex + 1}
               >
                 {pageNumber}

--- a/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageBtns.tsx
@@ -1,0 +1,60 @@
+import {
+  faBackwardFast,
+  faCaretLeft,
+  faCaretRight,
+  faForwardFast,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Table } from '@tanstack/react-table';
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
+interface HtPageBtnsProps<T> {
+  table: Table<T>;
+}
+
+/**
+ * Returns buttons for setting the page to view for a table.
+ * Built exclusively for use with the react-table (v8) library.
+ * https://tanstack.com/table/v8
+ * @param table
+ * @constructor
+ */
+export function HtPageBtns<T>({ table }: HtPageBtnsProps<T>) {
+  return (
+    <div className="d-flex justify-content-center">
+      <Button
+        variant="outline-secondary"
+        className="p-1 mx-1"
+        onClick={() => table.setPageIndex(0)}
+        disabled={!table.getCanPreviousPage()}
+      >
+        <FontAwesomeIcon icon={faBackwardFast} className="text-primary" />
+      </Button>
+      <Button
+        variant="outline-secondary"
+        className="p-1 mx-1"
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        <FontAwesomeIcon icon={faCaretLeft} className="text-primary" />
+      </Button>
+      <Button
+        variant="outline-secondary"
+        className="p-1 mx-1"
+        onClick={() => table.nextPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        <FontAwesomeIcon icon={faCaretRight} className="text-primary" />
+      </Button>
+      <Button
+        variant="outline-secondary"
+        className="p-1 mx-1"
+        onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+        disabled={!table.getCanNextPage()}
+      >
+        <FontAwesomeIcon icon={faForwardFast} className="text-primary" />
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/Ht/HtPaginate/HtPageControls.tsx
+++ b/client/src/components/Ht/HtPaginate/HtPageControls.tsx
@@ -1,0 +1,61 @@
+import { Table } from '@tanstack/react-table';
+import React from 'react';
+import { Col, Form, Row } from 'react-bootstrap';
+
+interface HtPageBtnsProps<T> {
+  table: Table<T>;
+}
+
+/**
+ * Returns display, and inputs for setting the page to view for a paginated table.
+ * Built exclusively for use with the react-table (v8) library.
+ * https://tanstack.com/table/v8
+ * also see HtPageBtns.tsx
+ * @param table
+ * @constructor
+ */
+export function HtPageControls<T>({ table }: HtPageBtnsProps<T>) {
+  return (
+    <Row className="d-flex justify-content-between pt-2">
+      <Col>
+        {'Page '}
+        <strong>{table.getState().pagination.pageIndex + 1}</strong>
+        {' of '}
+        <strong>{table.getPageCount()}</strong>
+      </Col>
+      <Col>
+        <div className="d-flex align-content-center gap-1">
+          <Form.Label htmlFor={'mtnPageNumber'}>{'Go to page:'}</Form.Label>
+          <Form.Control
+            type="number"
+            id={'mtnPageNumber'}
+            value={table.getState().pagination.pageIndex + 1}
+            style={{ width: '4rem' }}
+            className="py-0 px-1"
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0;
+              table.setPageIndex(page);
+            }}
+          />
+        </div>
+      </Col>
+      <Col className="d-flex justify-content-end">
+        <Col xs={9} xl={7}>
+          <Form.Select
+            aria-label="page size"
+            value={table.getState().pagination.pageSize}
+            onChange={(e) => {
+              table.setPageSize(Number(e.target.value));
+            }}
+          >
+            {[10, 20, 50, 100].map((pageSize) => (
+              <option key={pageSize} value={pageSize}>
+                Show {pageSize}
+              </option>
+            ))}
+          </Form.Select>
+        </Col>
+      </Col>
+    </Row>
+  );
+}

--- a/client/src/components/Ht/HtPaginate/index.ts
+++ b/client/src/components/Ht/HtPaginate/index.ts
@@ -1,4 +1,5 @@
 import { HtPaginate } from './HtPaginate';
 import { HtPageBtns } from './HtPageBtns';
+import { HtPageControls } from './HtPageControls';
 
-export { HtPaginate, HtPageBtns };
+export { HtPaginate, HtPageBtns, HtPageControls };

--- a/client/src/components/Ht/HtPaginate/index.ts
+++ b/client/src/components/Ht/HtPaginate/index.ts
@@ -1,3 +1,4 @@
 import { HtPaginate } from './HtPaginate';
+import { HtPageBtns } from './HtPageBtns';
 
-export { HtPaginate };
+export { HtPaginate, HtPageBtns };

--- a/client/src/components/Ht/index.ts
+++ b/client/src/components/Ht/index.ts
@@ -4,7 +4,7 @@ import { HtModal } from './HtModal';
 import { HtSpinner } from './HtSpinner';
 import { HtButton } from 'components/Ht/HtButton';
 import { HtForm } from 'components/Ht/HtForm';
-import { HtPaginate, HtPageBtns } from 'components/Ht/HtPaginate';
+import { HtPaginate, HtPageBtns, HtPageControls } from 'components/Ht/HtPaginate';
 import { HtTooltip, InfoIconTooltip } from './HtTooltip';
 
 export {
@@ -18,4 +18,5 @@ export {
   HtForm,
   HtPaginate,
   HtPageBtns,
+  HtPageControls,
 };

--- a/client/src/components/Ht/index.ts
+++ b/client/src/components/Ht/index.ts
@@ -4,7 +4,7 @@ import { HtModal } from './HtModal';
 import { HtSpinner } from './HtSpinner';
 import { HtButton } from 'components/Ht/HtButton';
 import { HtForm } from 'components/Ht/HtForm';
-import { HtPaginate } from 'components/Ht/HtPaginate';
+import { HtPaginate, HtPageBtns } from 'components/Ht/HtPaginate';
 import { HtTooltip, InfoIconTooltip } from './HtTooltip';
 
 export {
@@ -17,4 +17,5 @@ export {
   HtButton,
   HtForm,
   HtPaginate,
+  HtPageBtns,
 };

--- a/client/src/components/Mtn/MtnTable.spec.tsx
+++ b/client/src/components/Mtn/MtnTable.spec.tsx
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import { fireEvent } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event/setup/index';
 import { Manifest } from 'components/Manifest';
 import { MtnTable } from 'components/Mtn';
 import React from 'react';
@@ -24,5 +26,18 @@ describe('MtnTable', () => {
     const mtnData = [createMockMtnDetails(), createMockMtnDetails()];
     renderWithProviders(<MtnTable manifests={mtnData} />);
     expect(await screen.findAllByText(DEFAULT_MTN_DETAILS.manifestTrackingNumber)).toHaveLength(2);
+  });
+  test('filters', async () => {
+    const zeroMtn = '000000000ELC';
+    const oneMtn = '111111111ELC';
+    const mtnData = [
+      createMockMtnDetails({ manifestTrackingNumber: zeroMtn }),
+      createMockMtnDetails({ manifestTrackingNumber: oneMtn }),
+    ];
+    renderWithProviders(<MtnTable manifests={mtnData} />);
+    const filterInput = screen.getByPlaceholderText<HTMLInputElement>('Filter...');
+    fireEvent.change(filterInput, { target: { value: '00000' } });
+    expect(await screen.queryByText(oneMtn)).toBeNull();
+    expect(await screen.queryByText(zeroMtn)).not.toBeNull();
   });
 });

--- a/client/src/components/Mtn/MtnTable.spec.tsx
+++ b/client/src/components/Mtn/MtnTable.spec.tsx
@@ -1,25 +1,28 @@
 import '@testing-library/jest-dom';
+import { Manifest } from 'components/Manifest';
 import { MtnTable } from 'components/Mtn';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { MtnDetails } from 'components/Mtn';
 
-const manifestDetail: MtnDetails = {
+const DEFAULT_MTN_DETAILS: MtnDetails = {
   manifestTrackingNumber: '123456789ELC',
   status: 'InTransit',
   submissionType: 'FullElectronic',
   signatureStatus: false,
 };
 
-const mtnData = [manifestDetail, manifestDetail];
-
-afterEach(() => {
-  cleanup();
-});
+export function createMockMtnDetails(overWrites?: Partial<MtnDetails>): MtnDetails {
+  return {
+    ...DEFAULT_MTN_DETAILS,
+    ...overWrites,
+  };
+}
 
 describe('MtnTable', () => {
   test('renders', async () => {
+    const mtnData = [createMockMtnDetails(), createMockMtnDetails()];
     renderWithProviders(<MtnTable manifests={mtnData} />);
-    expect(await screen.findAllByText(manifestDetail.manifestTrackingNumber)).toHaveLength(2);
+    expect(await screen.findAllByText(DEFAULT_MTN_DETAILS.manifestTrackingNumber)).toHaveLength(2);
   });
 });

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -51,10 +51,12 @@ const columnHelper = createColumnHelper<MtnDetails>();
 const columns = [
   columnHelper.accessor('manifestTrackingNumber', {
     header: 'MTN',
+    enableColumnFilter: false,
     cell: (info) => info.getValue(), // example
   }),
   columnHelper.accessor('status', {
     header: 'Status',
+    enableColumnFilter: false,
     cell: (info) => {
       if (info.getValue() === 'ReadyForSignature') return 'Ready for Signature';
       else return info.getValue();
@@ -71,6 +73,7 @@ const columns = [
   }),
   columnHelper.accessor('actions', {
     header: 'Actions',
+    enableColumnFilter: false,
     cell: ({ row: { getValue } }: CellContext<MtnDetails, any>) => (
       <MtnRowActions mtn={getValue('manifestTrackingNumber')} />
     ),
@@ -122,6 +125,7 @@ export function MtnTable({ manifests }: MtnTableProps) {
     debugColumns: false,
   });
 
+  // @ts-ignore
   return (
     <>
       <Col xs={5}>
@@ -142,6 +146,19 @@ export function MtnTable({ manifests }: MtnTableProps) {
                   {header.isPlaceholder
                     ? null
                     : flexRender(header.column.columnDef.header, header.getContext())}
+                  {header.column.getCanFilter() ? (
+                    <div>
+                      <Form.Select
+                        className="py-0"
+                        // @ts-ignore
+                        value={header.column.getFilterValue()}
+                        onChange={(event) => header.column.setFilterValue(event.target.value)}
+                      >
+                        <option value="FullElectronic">Electronic</option>
+                        <option value="Hybrid">Hybrid</option>
+                      </Form.Select>
+                    </div>
+                  ) : null}
                 </th>
               ))}
             </tr>

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -1,10 +1,3 @@
-import {
-  faBackwardFast,
-  faCaretLeft,
-  faCaretRight,
-  faForwardFast,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { rankItem } from '@tanstack/match-sorter-utils';
 import {
   CellContext,
@@ -21,9 +14,10 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { HtPageBtns } from 'components/Ht';
 import { MtnRowActions } from 'components/Mtn/MtnRowActions';
 import React, { useState } from 'react';
-import { Button, Col, Form, Row, Table } from 'react-bootstrap';
+import { Col, Form, Row, Table } from 'react-bootstrap';
 import Select from 'react-select';
 import { z } from 'zod';
 
@@ -165,8 +159,6 @@ export function MtnTable({ manifests }: MtnTableProps) {
               setColumnFilters([{ id: 'status', value: newValue?.value ?? '' }]);
             }}
             options={statusOptions}
-            getOptionLabel={(option: StatusOption) => option.label}
-            getOptionValue={(option: StatusOption) => option.value}
             isClearable={true}
             placeholder="Status"
             classNames={{
@@ -201,40 +193,7 @@ export function MtnTable({ manifests }: MtnTableProps) {
           ))}
         </tbody>
       </Table>
-      <div className="d-flex justify-content-center">
-        <Button
-          variant="outline-secondary"
-          className="p-1 mx-1"
-          onClick={() => table.setPageIndex(0)}
-          disabled={!table.getCanPreviousPage()}
-        >
-          <FontAwesomeIcon icon={faBackwardFast} className="text-primary" />
-        </Button>
-        <Button
-          variant="outline-secondary"
-          className="p-1 mx-1"
-          onClick={() => table.previousPage()}
-          disabled={!table.getCanPreviousPage()}
-        >
-          <FontAwesomeIcon icon={faCaretLeft} className="text-primary" />
-        </Button>
-        <Button
-          variant="outline-secondary"
-          className="p-1 mx-1"
-          onClick={() => table.nextPage()}
-          disabled={!table.getCanNextPage()}
-        >
-          <FontAwesomeIcon icon={faCaretRight} className="text-primary" />
-        </Button>
-        <Button
-          variant="outline-secondary"
-          className="p-1 mx-1"
-          onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-          disabled={!table.getCanNextPage()}
-        >
-          <FontAwesomeIcon icon={faForwardFast} className="text-primary" />
-        </Button>
-      </div>
+      <HtPageBtns table={table} />
       <Row className="d-flex justify-content-between pt-2">
         <Col>
           {'Page '}

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -14,7 +14,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { HtPageBtns } from 'components/Ht';
+import { HtPageBtns, HtPageControls } from 'components/Ht';
 import { MtnRowActions } from 'components/Mtn/MtnRowActions';
 import React, { useState } from 'react';
 import { Col, Form, Row, Table } from 'react-bootstrap';
@@ -194,47 +194,7 @@ export function MtnTable({ manifests }: MtnTableProps) {
         </tbody>
       </Table>
       <HtPageBtns table={table} />
-      <Row className="d-flex justify-content-between pt-2">
-        <Col>
-          {'Page '}
-          <strong>{table.getState().pagination.pageIndex + 1}</strong>
-          {' of '}
-          <strong>{table.getPageCount()}</strong>
-        </Col>
-        <Col>
-          <div className="d-flex align-content-center gap-1">
-            <Form.Label htmlFor={'mtnPageNumber'}>{'Go to page:'}</Form.Label>
-            <Form.Control
-              type="number"
-              id={'mtnPageNumber'}
-              value={table.getState().pagination.pageIndex + 1}
-              style={{ width: '4rem' }}
-              className="py-0 px-1"
-              onChange={(e) => {
-                const page = e.target.value ? Number(e.target.value) - 1 : 0;
-                table.setPageIndex(page);
-              }}
-            />
-          </div>
-        </Col>
-        <Col className="d-flex justify-content-end">
-          <Col xs={9} xl={7}>
-            <Form.Select
-              aria-label="page size"
-              value={table.getState().pagination.pageSize}
-              onChange={(e) => {
-                table.setPageSize(Number(e.target.value));
-              }}
-            >
-              {[10, 20, 50, 100].map((pageSize) => (
-                <option key={pageSize} value={pageSize}>
-                  Show {pageSize}
-                </option>
-              ))}
-            </Form.Select>
-          </Col>
-        </Col>
-      </Row>
+      <HtPageControls table={table} />
     </>
   );
 }

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -24,6 +24,7 @@ import {
 import { MtnRowActions } from 'components/Mtn/MtnRowActions';
 import React, { useState } from 'react';
 import { Button, Col, Form, Row, Table } from 'react-bootstrap';
+import Select from 'react-select';
 import { z } from 'zod';
 
 const mtnDetailsSchema = z.object({
@@ -97,6 +98,20 @@ const fuzzyFilter: FilterFn<MtnDetails> = (row, columnId, value, addMeta) => {
   return itemRank.passed;
 };
 
+interface StatusOption {
+  value: string;
+  label: string;
+}
+
+const statusOptions: readonly StatusOption[] = [
+  { value: 'Scheduled', label: 'Scheduled' },
+  { value: 'InTransit', label: 'In Transit' },
+  { value: 'ReadyForSignature', label: 'Ready for Signature' },
+  { value: 'Corrected', label: 'Corrected' },
+  { value: 'Signed', label: 'Signed' },
+  { value: 'NotAssigned', label: 'Draft' },
+];
+
 /**
  * Returns a card with a table of manifest tracking numbers (MTN) and select details
  * @param manifest
@@ -134,23 +149,45 @@ export function MtnTable({ manifests }: MtnTableProps) {
     <>
       <div className="d-flex flex-row-reverse">
         <Col xs={5}>
-          <Form.Select
-            className="py-0 ms-2"
+          {/*<Form.Select*/}
+          {/*  className="py-0 ms-2"*/}
+          {/*  value={searchValue}*/}
+          {/*  placeholder={'Status'}*/}
+          {/*  onChange={(event) => {*/}
+          {/*    setSearchValue(event.target.value);*/}
+          {/*    setColumnFilters([{ id: 'status', value: event.target.value }]);*/}
+          {/*  }}*/}
+          {/*>*/}
+          {/*  <option value="" className="text-muted" hidden>*/}
+          {/*    Status*/}
+          {/*  </option>*/}
+          {/*  <option value="">--</option>*/}
+          {/*  <option value="Scheduled">Scheduled</option>*/}
+          {/*  <option value="NotAssigned">Draft</option>*/}
+          {/*  <option value="IntTransit">In Transit</option>*/}
+          {/*  <option value="ReadyForSignature">Ready for Signature</option>*/}
+          {/*  <option value="Signed">Signed</option>*/}
+          {/*  <option value="Corrected">Corrected</option>*/}
+          {/*</Form.Select>*/}
+          <Select
+            name="statusFilter"
             value={searchValue}
-            placeholder={'Status'}
-            onChange={(event) => {
-              setSearchValue(event.target.value);
-              setColumnFilters([{ id: 'status', value: event.target.value }]);
+            onChange={(newValue) => {
+              setSearchValue(newValue ?? '');
+              setColumnFilters([{ id: 'status', value: newValue?.value ?? '' }]);
             }}
-          >
-            <option value="">--</option>
-            <option value="Scheduled">Scheduled</option>
-            <option value="NotAssigned">Draft</option>
-            <option value="IntTransit">In Transit</option>
-            <option value="ReadyForSignature">Ready for Signature</option>
-            <option value="Signed">Signed</option>
-            <option value="Corrected">Corrected</option>
-          </Form.Select>
+            options={statusOptions}
+            getOptionLabel={(option) => option.label}
+            getOptionValue={(option) => option.value}
+            isClearable={true}
+            placeholder="Status"
+            classNames={{
+              control: () => 'form-select py-0 ms-2 rounded-3',
+              valueContainer: () => 'p-0 m-0',
+              placeholder: () => 'p-0 m-0',
+            }}
+            components={{ IndicatorSeparator: () => null, DropdownIndicator: () => null }}
+          />
         </Col>
         <Col xs={3}>
           <Form.Control

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -106,7 +106,7 @@ interface StatusOption {
 const statusOptions: readonly StatusOption[] = [
   { value: 'Scheduled', label: 'Scheduled' },
   { value: 'InTransit', label: 'In Transit' },
-  { value: 'ReadyForSignature', label: 'Ready for Signature' },
+  { value: 'ReadyForSignature', label: 'Ready to Sign' },
   { value: 'Corrected', label: 'Corrected' },
   { value: 'Signed', label: 'Signed' },
   { value: 'NotAssigned', label: 'Draft' },
@@ -147,28 +147,16 @@ export function MtnTable({ manifests }: MtnTableProps) {
 
   return (
     <>
-      <div className="d-flex flex-row-reverse">
-        <Col xs={5}>
-          {/*<Form.Select*/}
-          {/*  className="py-0 ms-2"*/}
-          {/*  value={searchValue}*/}
-          {/*  placeholder={'Status'}*/}
-          {/*  onChange={(event) => {*/}
-          {/*    setSearchValue(event.target.value);*/}
-          {/*    setColumnFilters([{ id: 'status', value: event.target.value }]);*/}
-          {/*  }}*/}
-          {/*>*/}
-          {/*  <option value="" className="text-muted" hidden>*/}
-          {/*    Status*/}
-          {/*  </option>*/}
-          {/*  <option value="">--</option>*/}
-          {/*  <option value="Scheduled">Scheduled</option>*/}
-          {/*  <option value="NotAssigned">Draft</option>*/}
-          {/*  <option value="IntTransit">In Transit</option>*/}
-          {/*  <option value="ReadyForSignature">Ready for Signature</option>*/}
-          {/*  <option value="Signed">Signed</option>*/}
-          {/*  <option value="Corrected">Corrected</option>*/}
-          {/*</Form.Select>*/}
+      <div className="d-flex flex-row justify-content-end">
+        <Col xs={3}>
+          <Form.Control
+            id={'mtnGlobalSearch'}
+            value={globalFilter ?? ''}
+            onChange={(event) => setGlobalFilter(event.target.value)}
+            placeholder="Filter..."
+          />
+        </Col>
+        <Col xs={4} className="mx-2">
           <Select
             name="statusFilter"
             value={searchValue}
@@ -183,19 +171,9 @@ export function MtnTable({ manifests }: MtnTableProps) {
             placeholder="Status"
             classNames={{
               control: () => 'form-select py-0 ms-2 rounded-3',
-              valueContainer: () => 'p-0 m-0 ps-1',
-              placeholder: () => 'p-0 m-0',
+              placeholder: () => 'p-0 m-0 ps-1',
             }}
             components={{ IndicatorSeparator: () => null, DropdownIndicator: () => null }}
-          />
-        </Col>
-        <Col xs={3}>
-          <Form.Control
-            id={'mtnGlobalSearch'}
-            value={globalFilter ?? ''}
-            onChange={(event) => setGlobalFilter(event.target.value)}
-            placeholder="Filter..."
-            className="py-0"
           />
         </Col>
       </div>

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -128,15 +128,17 @@ export function MtnTable({ manifests }: MtnTableProps) {
   // @ts-ignore
   return (
     <>
-      <Col xs={5}>
-        <HtForm.Label htmlFor={'mtnGlobalSearch'}>Global Search</HtForm.Label>
-        <Form.Control
-          id={'mtnGlobalSearch'}
-          value={globalFilter ?? ''}
-          onChange={(event) => setGlobalFilter(event.target.value)}
-          placeholder="Search manifests by all fields..."
-        />
-      </Col>
+      <div className="d-flex flex-row-reverse">
+        <Col xs={5}>
+          <Form.Control
+            id={'mtnGlobalSearch'}
+            value={globalFilter ?? ''}
+            onChange={(event) => setGlobalFilter(event.target.value)}
+            placeholder="Filter..."
+            className="py-0"
+          />
+        </Col>
+      </div>
       <Table>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
@@ -146,19 +148,6 @@ export function MtnTable({ manifests }: MtnTableProps) {
                   {header.isPlaceholder
                     ? null
                     : flexRender(header.column.columnDef.header, header.getContext())}
-                  {header.column.getCanFilter() ? (
-                    <div>
-                      <Form.Select
-                        className="py-0"
-                        // @ts-ignore
-                        value={header.column.getFilterValue()}
-                        onChange={(event) => header.column.setFilterValue(event.target.value)}
-                      >
-                        <option value="FullElectronic">Electronic</option>
-                        <option value="Hybrid">Hybrid</option>
-                      </Form.Select>
-                    </div>
-                  ) : null}
                 </th>
               ))}
             </tr>

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -17,7 +17,7 @@ import {
 import { HtPageBtns, HtPageControls } from 'components/Ht';
 import { MtnRowActions } from 'components/Mtn/MtnRowActions';
 import React, { useState } from 'react';
-import { Col, Form, Row, Table } from 'react-bootstrap';
+import { Col, Form, Table } from 'react-bootstrap';
 import Select from 'react-select';
 import { z } from 'zod';
 
@@ -34,7 +34,6 @@ const mtnDetailsSchema = z.object({
     'InTransit',
     'UnderCorrection',
   ]),
-  actions: z.any().optional(),
 });
 
 /**
@@ -50,6 +49,7 @@ interface MtnTableProps {
 
 const columnHelper = createColumnHelper<MtnDetails>();
 
+// This defines our MTN table's columns and their behavior
 const columns = [
   columnHelper.accessor('manifestTrackingNumber', {
     header: 'MTN',
@@ -74,12 +74,12 @@ const columns = [
     },
     enableGlobalFilter: false,
   }),
-  columnHelper.accessor('actions', {
+  columnHelper.display({
+    id: 'actions',
     header: 'Actions',
     cell: ({ row: { getValue } }: CellContext<MtnDetails, any>) => (
       <MtnRowActions mtn={getValue('manifestTrackingNumber')} />
     ),
-    enableGlobalFilter: false,
   }),
 ];
 

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -25,7 +25,15 @@ const mtnDetailsSchema = z.object({
   manifestTrackingNumber: z.string(),
   signatureStatus: z.boolean(),
   submissionType: z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image', 'NotSelected']),
-  status: z.enum(['Scheduled', 'Signed', 'Corrected', 'ReadyForSignature', 'Draft', 'InTransit']),
+  status: z.enum([
+    'Scheduled',
+    'Signed',
+    'Corrected',
+    'ReadyForSignature',
+    'Draft',
+    'InTransit',
+    'UnderCorrection',
+  ]),
   actions: z.any().optional(),
 });
 
@@ -51,6 +59,7 @@ const columns = [
     header: 'Status',
     cell: (info) => {
       if (info.getValue() === 'ReadyForSignature') return 'Ready for Signature';
+      if (info.getValue() === 'UnderCorrection') return 'Under Correction';
       else return info.getValue();
     },
     enableGlobalFilter: false,
@@ -104,6 +113,7 @@ const statusOptions: readonly StatusOption[] = [
   { value: 'Corrected', label: 'Corrected' },
   { value: 'Signed', label: 'Signed' },
   { value: 'NotAssigned', label: 'Draft' },
+  { value: 'UnderCorrection', label: 'Under Correction' },
 ];
 
 /**

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -118,7 +118,7 @@ const statusOptions: readonly StatusOption[] = [
  */
 export function MtnTable({ manifests }: MtnTableProps) {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const [searchValue, setSearchValue] = useState('');
+  const [searchValue, setSearchValue] = useState<StatusOption | null>(null);
   const [globalFilter, setGlobalFilter] = useState('');
   const table = useReactTable({
     columns,
@@ -173,17 +173,17 @@ export function MtnTable({ manifests }: MtnTableProps) {
             name="statusFilter"
             value={searchValue}
             onChange={(newValue) => {
-              setSearchValue(newValue ?? '');
+              setSearchValue(newValue);
               setColumnFilters([{ id: 'status', value: newValue?.value ?? '' }]);
             }}
             options={statusOptions}
-            getOptionLabel={(option) => option.label}
-            getOptionValue={(option) => option.value}
+            getOptionLabel={(option: StatusOption) => option.label}
+            getOptionValue={(option: StatusOption) => option.value}
             isClearable={true}
             placeholder="Status"
             classNames={{
               control: () => 'form-select py-0 ms-2 rounded-3',
-              valueContainer: () => 'p-0 m-0',
+              valueContainer: () => 'p-0 m-0 ps-1',
               placeholder: () => 'p-0 m-0',
             }}
             components={{ IndicatorSeparator: () => null, DropdownIndicator: () => null }}

--- a/client/src/features/manifest/Manifest.tsx
+++ b/client/src/features/manifest/Manifest.tsx
@@ -1,6 +1,6 @@
 import { ManifestDetails } from './ManifestDetails';
 import { ManifestList } from 'features/manifest/ManifestList';
-import { ManifestNew } from './ManifestNew';
+import { NewManifest } from 'features/manifest/NewManifest';
 import React, { ReactElement } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Container } from 'react-bootstrap';
@@ -10,7 +10,7 @@ export function Manifest(): ReactElement {
     <Container fluid className="py-2">
       <Routes>
         <Route path="" element={<ManifestList />} />
-        <Route path="new" element={<ManifestNew />} />
+        <Route path="new" element={<NewManifest />} />
         <Route path=":mtn/:action" element={<ManifestDetails />} />
       </Routes>
     </Container>

--- a/client/src/features/manifest/NewManifest.tsx
+++ b/client/src/features/manifest/NewManifest.tsx
@@ -11,7 +11,7 @@ import { useParams } from 'react-router-dom';
 import { useAppSelector } from 'store';
 import { getSiteByEpaId } from 'store/rcraProfileSlice/rcraProfile.slice';
 
-export function ManifestNew() {
+export function NewManifest() {
   useTitle('New Manifest');
   const { siteId } = useParams();
   const { control } = useForm();

--- a/client/src/hooks/usePagination/usePagination.spec.tsx
+++ b/client/src/hooks/usePagination/usePagination.spec.tsx
@@ -15,7 +15,7 @@ interface TestUsePagProps {
 const defaultTotalCount = 101;
 const defaultCurrentPage = 1;
 const defaultPageSize = 10;
-const newTotalCount = 151;
+const newTotalCount = 51;
 
 function TestPaginationHook({
   totalCount = defaultTotalCount,
@@ -55,7 +55,7 @@ afterEach(() => {
 
 describe('usePagination', () => {
   test('defaults to returning a simple array', async () => {
-    render(<TestPaginationHook />);
+    render(<TestPaginationHook maxVisiblePages={Math.ceil(defaultTotalCount / defaultPageSize)} />);
     const paginationRange = await screen.findAllByTestId('item');
     expect(paginationRange).toHaveLength(Math.ceil(defaultTotalCount / defaultPageSize));
   });
@@ -82,7 +82,7 @@ describe('usePagination', () => {
     expect(paginationRange).toHaveLength(numExpectedElements);
   });
   test('updates when number of elements changes', async () => {
-    render(<TestPaginationHook />);
+    render(<TestPaginationHook maxVisiblePages={Math.ceil(defaultTotalCount / defaultPageSize)} />);
     const paginationRange = await screen.findAllByTestId('item');
     expect(paginationRange).toHaveLength(Math.ceil(defaultTotalCount / defaultPageSize));
     fireEvent.click(screen.getByText('Click Me'));

--- a/client/src/hooks/usePagination/usePagination.tsx
+++ b/client/src/hooks/usePagination/usePagination.tsx
@@ -30,7 +30,7 @@ export function usePagination({
   totalCount,
   pageSize,
   siblingCount = 1,
-  maxVisiblePages = 9,
+  maxVisiblePages = 7,
   currentPage,
   useEllipsis = false,
 }: usePaginationProps) {

--- a/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
+++ b/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
@@ -119,7 +119,9 @@ describe('RcraProfileSlice selectors', () => {
         <>
           <p>{myRcraSite ? Object.keys(myRcraSite).length : 'not defined'}</p>
           {myRcraSite
-            ? myRcraSite.map((site) => <p>{site.site.handler.epaSiteId}</p>)
+            ? myRcraSite.map((site, index) => (
+                <p key={`${site.site.handler.epaSiteId}-${index}`}>{site.site.handler.epaSiteId}</p>
+              ))
             : 'not defined'}
         </>
       );
@@ -143,7 +145,6 @@ describe('RcraProfileSlice selectors', () => {
         },
       },
     });
-    screen.debug();
     expect(screen.getByText('2')).toBeInTheDocument();
     expect(screen.queryByText(/Not Defined/i)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Description

This PR adds the functionality necessary to filter the manifest table by the manifest's current status (users can already filter by MTN). 

In addition, it also updates the pagination component to give it a fresh look and ensure that ellipsis are displayed correctly 
for example, the three scenarios below...

ellipsis right of active page
![image](https://github.com/USEPA/haztrak/assets/43794491/2f531e0a-349c-4fcf-a81b-8d687aba9c96)


ellipsis left of active page
![image](https://github.com/USEPA/haztrak/assets/43794491/935bfd65-ceaa-4de3-923b-e19f556e578e)

ellipsis on both sides of active page
![image](https://github.com/USEPA/haztrak/assets/43794491/0dfcbf3d-dc0d-4d86-b12d-8e2d4de5f0a3)

This PR udpates the inline comments in the `usePagination` custom hook to be a little more helpful.

tests are included. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->


## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
