### PR TITLE
Mtn table sorting

### DIFF
--- a/client/src/components/Mtn/MtnTable.spec.tsx
+++ b/client/src/components/Mtn/MtnTable.spec.tsx
@@ -1,10 +1,8 @@
 import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event/setup/index';
-import { Manifest } from 'components/Manifest';
 import { MtnTable } from 'components/Mtn';
 import React from 'react';
-import { cleanup, renderWithProviders, screen } from 'test-utils';
+import { renderWithProviders, screen } from 'test-utils';
 import { MtnDetails } from 'components/Mtn';
 
 const DEFAULT_MTN_DETAILS: MtnDetails = {

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -17,7 +17,7 @@ import {
 import { HtPageBtns, HtPageControls } from 'components/Ht';
 import { MtnRowActions } from 'components/Mtn/MtnRowActions';
 import React, { useState } from 'react';
-import { Col, Form, Table } from 'react-bootstrap';
+import { Button, Col, Form, Table } from 'react-bootstrap';
 import Select from 'react-select';
 import { z } from 'zod';
 
@@ -77,6 +77,7 @@ const columns = [
   columnHelper.display({
     id: 'actions',
     header: 'Actions',
+
     cell: ({ row: { getValue } }: CellContext<MtnDetails, any>) => (
       <MtnRowActions mtn={getValue('manifestTrackingNumber')} />
     ),
@@ -185,9 +186,26 @@ export function MtnTable({ manifests }: MtnTableProps) {
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <th key={header.id}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
+                  {header.column.getCanSort() ? (
+                    header.isPlaceholder ? null : (
+                      <Button
+                        className="bg-transparent border-0 cursor-pointer select-none p-0 text-dark fw-bolder"
+                        {...{
+                          onClick: header.column.getToggleSortingHandler(),
+                        }}
+                      >
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        {{
+                          asc: ' 🔼',
+                          desc: ' 🔽',
+                        }[header.column.getIsSorted() as string] ?? null}
+                      </Button>
+                    )
+                  ) : (
+                    <div className="text-center">
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                    </div>
+                  )}
                 </th>
               ))}
             </tr>

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -20,6 +20,8 @@ import React, { useState } from 'react';
 import { Button, Col, Form, Table } from 'react-bootstrap';
 import Select from 'react-select';
 import { z } from 'zod';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSort, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
 
 const mtnDetailsSchema = z.object({
   manifestTrackingNumber: z.string(),
@@ -186,6 +188,7 @@ export function MtnTable({ manifests }: MtnTableProps) {
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <th key={header.id}>
+                  {/* if sortable, column header is clickable */}
                   {header.column.getCanSort() ? (
                     header.isPlaceholder ? null : (
                       <Button
@@ -194,14 +197,35 @@ export function MtnTable({ manifests }: MtnTableProps) {
                           onClick: header.column.getToggleSortingHandler(),
                         }}
                       >
+                        {/* If column is sortable */}
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {{
-                          asc: ' 🔼',
-                          desc: ' 🔽',
-                        }[header.column.getIsSorted() as string] ?? null}
+                          // Column sort icon when ascending order
+                          asc: (
+                            <>
+                              {' '}
+                              <FontAwesomeIcon icon={faSortUp} className="text-info" />
+                            </>
+                          ),
+                          // Column sort icon when descending order
+                          desc: (
+                            <>
+                              {' '}
+                              <FontAwesomeIcon icon={faSortDown} className="text-info" />
+                            </>
+                          ),
+                        }[header.column.getIsSorted() as string] ?? (
+                          <>
+                            {' '}
+                            {/* Default column sort icon when not sorting by this column*/}
+                            <FontAwesomeIcon icon={faSort} className="text-info" />
+                          </>
+                        )}
                       </Button>
                     )
                   ) : (
+                    // If column is defined a 'display' in our ColumnDef (columnHelpers)
+                    // Just display the 'Header' value as a string
                     <div className="text-center">
                       {flexRender(header.column.columnDef.header, header.getContext())}
                     </div>


### PR DESCRIPTION
## Description

This PR adds the ability to sort the MtnTable component (Manifest table) alphanumerically by the existing columns. We do not serialize the last update date on the server (like mentioned in #415), however, this sets up the infrastructure for sorting by a column.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
relevant to #415 

## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
