### PR TITLE
Transporter required validation

### DIFF
--- a/client/src/components/AdditionalInfo/additionalInfoSchema.ts
+++ b/client/src/components/AdditionalInfo/additionalInfoSchema.ts
@@ -10,9 +10,9 @@ export const additionalInfoCommentSchema = z.object({
 });
 
 export const additionalInfoSchema = z.object({
-  originalManifestTrackingNumbers: z.string().array().optional(),
-  newManifestDestination: z.enum(['Tsdf', 'OriginalGenerator']).optional(),
-  consentNumber: z.string().optional(),
+  originalManifestTrackingNumbers: z.string().array().optional().nullable(),
+  newManifestDestination: z.enum(['Tsdf', 'OriginalGenerator']).optional().nullable(),
+  consentNumber: z.string().optional().nullable(),
   comments: additionalInfoCommentSchema.array().optional(),
 });
 

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -112,7 +112,8 @@ export function ManifestForm({
     manifestStatus === 'InTransit' ||
     manifestStatus === 'ReadyForSignature';
 
-  // console.log('errors', errors);
+  console.log(manifestData);
+  if (errors) console.log('errors', errors);
 
   return (
     <>

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -5,7 +5,7 @@ import { ContactForm, PhoneForm } from './Contact';
 import { Transporter, TransporterTable } from './Transporter';
 import { WasteLineTable, AddWasteLine } from './WasteLine';
 import React, { useEffect, useState } from 'react';
-import { Button, Col, Form, Row } from 'react-bootstrap';
+import { Alert, Button, Col, Form, Row } from 'react-bootstrap';
 import { FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { QuickerSignData } from './QuickerSign';
@@ -407,7 +407,11 @@ export function ManifestForm({
               <ErrorMessage
                 errors={errors}
                 name={'transporters'}
-                render={({ message }) => <span className="text-danger">{message}</span>}
+                render={({ message }) => (
+                  <Alert variant="danger" className="text-center m-3">
+                    {message}
+                  </Alert>
+                )}
               />
             </HtCard.Body>
           </HtCard>

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -153,9 +153,8 @@ export const manifestSchema = z
     return true;
   })
   .refine(
-    (manifest) => {
-      return manifest.transporters.length >= 1;
-    },
+    // check that the manifest has at least 1 transporter
+    (manifest) => manifest.transporters.length >= 1,
     { path: ['transporters'], message: 'A manifest requires at least 1 transporters' }
   );
 

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -151,7 +151,13 @@ export const manifestSchema = z
   .refine(() => {
     // ToDo Validate that if submission Type is FullElectronic, generator.canEsign is true
     return true;
-  });
+  })
+  .refine(
+    (manifest) => {
+      return manifest.transporters.length >= 1;
+    },
+    { path: ['transporters'], message: 'A manifest requires 1 of more transporters' }
+  );
 
 const rejectionInfoSchema = z.object({
   rejectionType: z.enum(['FullRejection', 'PartialRejection']),

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -156,7 +156,7 @@ export const manifestSchema = z
     (manifest) => {
       return manifest.transporters.length >= 1;
     },
-    { path: ['transporters'], message: 'A manifest requires 1 of more transporters' }
+    { path: ['transporters'], message: 'A manifest requires at least 1 transporters' }
   );
 
 const rejectionInfoSchema = z.object({


### PR DESCRIPTION
## Description

This small PR adds validation to our front end for draft manifests that requires user to supply at least 1 transporter. 

simple as that. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
closes #468 

## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
