### PR TITLE
remove ad hoc selectors

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,8 +16,8 @@ import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'store';
 import './App.scss';
 import { getProfile } from 'store/rcraProfileSlice';
-import { RcraProfileState, selectRcraProfile } from 'store/rcraProfileSlice/rcraProfile.slice';
-import { selectUserName } from 'store/userSlice/user.slice';
+import { selectRcraProfile } from 'store/rcraProfileSlice';
+import { selectUserName } from 'store/userSlice';
 
 function App(): ReactElement {
   const userName = useAppSelector(selectUserName);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,19 +13,20 @@ import { Sites } from 'features/haztrakSite';
 import React, { ReactElement, useEffect } from 'react';
 import { Button, Container } from 'react-bootstrap';
 import { Route, Routes, useNavigate } from 'react-router-dom';
-import { RootState, useAppDispatch, useAppSelector } from 'store';
+import { useAppDispatch, useAppSelector } from 'store';
 import './App.scss';
 import { getProfile } from 'store/rcraProfileSlice';
 import { RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { selectUserName } from 'store/userSlice/user.slice';
 
 function App(): ReactElement {
-  const { user } = useAppSelector((state: RootState) => state.user);
+  const userName = useAppSelector(selectUserName);
   const profile = useAppSelector<RcraProfileState>((state) => state.rcraProfile);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (user) {
+    if (userName) {
       dispatch(getProfile());
     }
   }, [profile.user]);
@@ -41,7 +42,7 @@ function App(): ReactElement {
               <Route
                 path="/"
                 element={
-                  <PrivateRoute authUser={user}>
+                  <PrivateRoute authUser={userName}>
                     <Home />
                   </PrivateRoute>
                 }
@@ -49,7 +50,7 @@ function App(): ReactElement {
               <Route
                 path="/notifications"
                 element={
-                  <PrivateRoute authUser={user}>
+                  <PrivateRoute authUser={userName}>
                     <Notifications />
                   </PrivateRoute>
                 }
@@ -57,7 +58,7 @@ function App(): ReactElement {
               <Route
                 path="/profile/*"
                 element={
-                  <PrivateRoute authUser={user}>
+                  <PrivateRoute authUser={userName}>
                     <Profile />
                   </PrivateRoute>
                 }
@@ -65,15 +66,15 @@ function App(): ReactElement {
               <Route
                 path="/site/*"
                 element={
-                  <PrivateRoute authUser={user}>
-                    <Sites user={user ? user : ''} />
+                  <PrivateRoute authUser={userName}>
+                    <Sites user={userName ? userName : ''} />
                   </PrivateRoute>
                 }
               />
               <Route
                 path="/manifest/*"
                 element={
-                  <PrivateRoute authUser={user}>
+                  <PrivateRoute authUser={userName}>
                     <Manifest />
                   </PrivateRoute>
                 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,12 +16,12 @@ import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'store';
 import './App.scss';
 import { getProfile } from 'store/rcraProfileSlice';
-import { RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { RcraProfileState, selectRcraProfile } from 'store/rcraProfileSlice/rcraProfile.slice';
 import { selectUserName } from 'store/userSlice/user.slice';
 
 function App(): ReactElement {
   const userName = useAppSelector(selectUserName);
-  const profile = useAppSelector<RcraProfileState>((state) => state.rcraProfile);
+  const profile = useAppSelector(selectRcraProfile);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 

--- a/client/src/components/Manifest/QuickerSign/QuickerSignForm.tsx
+++ b/client/src/components/Manifest/QuickerSign/QuickerSignForm.tsx
@@ -5,7 +5,7 @@ import { Handler, RcraSiteType } from 'components/Manifest/manifestSchema';
 import React from 'react';
 import { Button, Col, Container, Form, ListGroup, Row } from 'react-bootstrap';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { selectUserName, UserState } from 'store/userSlice/user.slice';
+import { selectUserName } from 'store/userSlice';
 import { useNavigate } from 'react-router-dom';
 import { addNotification, useAppDispatch, useAppSelector } from 'store';
 import { htApi } from 'services';

--- a/client/src/components/Manifest/QuickerSign/QuickerSignForm.tsx
+++ b/client/src/components/Manifest/QuickerSign/QuickerSignForm.tsx
@@ -5,9 +5,9 @@ import { Handler, RcraSiteType } from 'components/Manifest/manifestSchema';
 import React from 'react';
 import { Button, Col, Container, Form, ListGroup, Row } from 'react-bootstrap';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { UserState } from 'store/userSlice/user.slice';
+import { selectUserName, UserState } from 'store/userSlice/user.slice';
 import { useNavigate } from 'react-router-dom';
-import { addNotification, RootState, useAppDispatch, useAppSelector } from 'store';
+import { addNotification, useAppDispatch, useAppSelector } from 'store';
 import { htApi } from 'services';
 import { AxiosError, AxiosResponse } from 'axios';
 import { QuickerSignature } from 'components/Manifest/QuickerSign/quickerSignSchema';
@@ -30,11 +30,11 @@ interface QuickerSignProps {
  * @constructor
  */
 export function QuickerSignForm({ mtn, mtnHandler, handleClose, siteType }: QuickerSignProps) {
-  const { user } = useAppSelector<UserState>((state: RootState) => state.user);
+  const userName = useAppSelector(selectUserName);
   const dispatch = useAppDispatch();
   const { register, handleSubmit, setValue } = useForm<QuickerSignature>({
     defaultValues: {
-      printedSignatureName: user,
+      printedSignatureName: userName,
       printedSignatureDate: new Date().toISOString().slice(0, -8),
     },
   });

--- a/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
+++ b/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Control, Controller } from 'react-hook-form';
 import Select from 'react-select';
 import { RootState, useAppSelector } from 'store';
-import { selectUserSites, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { userSiteSelector, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
 
 interface SiteSelectProps<T> {
   control: Control;
@@ -17,7 +17,7 @@ export function SiteSelect({
   selectedSite,
   setSelectedSite,
 }: SiteSelectProps<RcraSite | undefined | null>) {
-  const rcraSite = useAppSelector(selectUserSites);
+  const rcraSite = useAppSelector(userSiteSelector);
   const siteOptions = rcraSite?.map((site) => site.site.handler);
   return (
     <>

--- a/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
+++ b/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Control, Controller } from 'react-hook-form';
 import Select from 'react-select';
 import { RootState, useAppSelector } from 'store';
-import { userSiteSelector, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { userRcraSitesSelector, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
 
 interface SiteSelectProps<T> {
   control: Control;
@@ -17,8 +17,8 @@ export function SiteSelect({
   selectedSite,
   setSelectedSite,
 }: SiteSelectProps<RcraSite | undefined | null>) {
-  const rcraSite = useAppSelector(userSiteSelector);
-  const siteOptions = rcraSite?.map((site) => site.site.handler);
+  const userRcraSites = useAppSelector(userRcraSitesSelector);
+  const siteOptions = userRcraSites?.map((site) => site.site.handler);
   return (
     <>
       <HtForm.Label htmlFor="site">Site</HtForm.Label>

--- a/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
+++ b/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Control, Controller } from 'react-hook-form';
 import Select from 'react-select';
 import { RootState, useAppSelector } from 'store';
-import { getUserSites, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { selectUserSites, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
 
 interface SiteSelectProps<T> {
   control: Control;
@@ -17,7 +17,7 @@ export function SiteSelect({
   selectedSite,
   setSelectedSite,
 }: SiteSelectProps<RcraSite | undefined | null>) {
-  const rcraSite = useAppSelector(getUserSites);
+  const rcraSite = useAppSelector(selectUserSites);
   const siteOptions = rcraSite?.map((site) => site.site.handler);
   return (
     <>

--- a/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
+++ b/client/src/components/Manifest/SiteSelect/SiteSelect.tsx
@@ -3,8 +3,8 @@ import { RcraSite } from 'components/RcraSite';
 import React from 'react';
 import { Control, Controller } from 'react-hook-form';
 import Select from 'react-select';
-import { RootState, useAppSelector } from 'store';
-import { userRcraSitesSelector, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { useAppSelector } from 'store';
+import { userRcraSitesSelector } from 'store/rcraProfileSlice/rcraProfile.slice';
 
 interface SiteSelectProps<T> {
   control: Control;

--- a/client/src/components/Notification/NotificationBtn.tsx
+++ b/client/src/components/Notification/NotificationBtn.tsx
@@ -4,10 +4,11 @@ import { Link } from 'react-router-dom';
 import { useAppSelector } from 'store';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
+import { selectNotifications } from 'store/notificationSlice';
 
 export function NotificationBtn() {
-  const notificationState = useAppSelector((state) => state.notification);
-  const numberAlerts = notificationState.notifications.length;
+  const notifications = useAppSelector(selectNotifications);
+  const numberAlerts = notifications.length;
   const alertsExists: boolean = numberAlerts > 0;
 
   return (

--- a/client/src/components/buttons/RcraApiUserBtn/RcraApiUserBtn.tsx
+++ b/client/src/components/buttons/RcraApiUserBtn/RcraApiUserBtn.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps } from 'react-bootstrap';
 import { useAppSelector } from 'store';
-import { RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { RcraProfileState, selectRcraProfile } from 'store/rcraProfileSlice/rcraProfile.slice';
 
 interface HtApiUserBtnProps extends ButtonProps {}
 
@@ -12,7 +12,7 @@ interface HtApiUserBtnProps extends ButtonProps {}
  * @constructor
  */
 export function RcraApiUserBtn(props: HtApiUserBtnProps) {
-  const profile = useAppSelector<RcraProfileState>((state) => state.rcraProfile);
+  const profile = useAppSelector(selectRcraProfile);
   let { children, ...btnProps } = props;
   // In order for the button to be active,
   // the disabled prop needs to be falsy AND the user needs to be an API user

--- a/client/src/components/buttons/RcraApiUserBtn/RcraApiUserBtn.tsx
+++ b/client/src/components/buttons/RcraApiUserBtn/RcraApiUserBtn.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps } from 'react-bootstrap';
 import { useAppSelector } from 'store';
-import { RcraProfileState, selectRcraProfile } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { selectRcraProfile } from 'store/rcraProfileSlice';
 
 interface HtApiUserBtnProps extends ButtonProps {}
 

--- a/client/src/features/home/Home.tsx
+++ b/client/src/features/home/Home.tsx
@@ -5,10 +5,10 @@ import { useTitle } from 'hooks';
 import React, { ReactElement, useEffect } from 'react';
 import { Accordion, Button, Col, Container, Row } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
-import { RootState, useAppDispatch, useAppSelector } from 'store';
+import { useAppDispatch, useAppSelector } from 'store';
 import { getExampleTask } from 'store/notificationSlice/notification.slice';
 import { getProfile } from 'store/rcraProfileSlice';
-import { selectUserName, UserState } from 'store/userSlice/user.slice';
+import { selectUserName } from 'store/userSlice/user.slice';
 import { HtButton, HtCard } from 'components/Ht';
 
 /**

--- a/client/src/features/home/Home.tsx
+++ b/client/src/features/home/Home.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 import { RootState, useAppDispatch, useAppSelector } from 'store';
 import { getExampleTask } from 'store/notificationSlice/notification.slice';
 import { getProfile } from 'store/rcraProfileSlice';
-import { UserState } from 'store/userSlice/user.slice';
+import { selectUserName, UserState } from 'store/userSlice/user.slice';
 import { HtButton, HtCard } from 'components/Ht';
 
 /**
@@ -18,12 +18,12 @@ import { HtButton, HtCard } from 'components/Ht';
 export function Home(): ReactElement {
   useTitle(`Haztrak`, false, true);
   const dispatch = useAppDispatch();
-  const { user } = useAppSelector<UserState>((state: RootState) => state.user);
+  const userName = useAppSelector(selectUserName);
 
   useEffect(() => {
     // get user profile information when the user changes
     dispatch(getProfile());
-  }, [user]);
+  }, [userName]);
 
   return (
     <Container className="py-2">

--- a/client/src/features/login/Login.tsx
+++ b/client/src/features/login/Login.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { login, useAppDispatch, useAppSelector } from 'store';
 import { useNavigate } from 'react-router-dom';
 import { useTitle } from 'hooks';
+import { selectUser } from 'store/userSlice';
 import { z } from 'zod';
 import { Col, Container, Form, Row } from 'react-bootstrap';
 import logo from 'assets/haztrak-logos/low-resolution/svg/haztrak-low-resolution-logo-black-on-transparent-background.svg';
@@ -23,9 +24,7 @@ type LoginSchema = z.infer<typeof loginSchema>;
 export function Login(): ReactElement {
   useTitle('Login');
   const dispatch = useAppDispatch();
-  const useSelector = useAppSelector;
-  const authUser = useSelector((state) => state.user.user);
-  const authError = useSelector((state) => state.user.error);
+  const user = useAppSelector(selectUser);
   const navigation = useNavigate();
   const {
     register,
@@ -35,10 +34,10 @@ export function Login(): ReactElement {
 
   useEffect(() => {
     // redirect to home if already logged in
-    if (authUser) {
+    if (user.user) {
       navigation('/');
     }
-  }, [authUser]);
+  }, [user.user]);
 
   function onSubmit({ username, password }: LoginSchema) {
     return dispatch(login({ username, password }));
@@ -87,44 +86,12 @@ export function Login(): ReactElement {
                   {isSubmitting && <span className="spinner-border spinner-border-sm mr-1" />}
                   Login
                 </button>
-                {authError && <div className="alert alert-danger mt-3 mb-0">{authError}</div>}
+                {user.error && (
+                  <div className="alert alert-danger mt-3 mb-0">{String(user.error)}</div>
+                )}
               </HtForm>
             </HtCard.Body>
           </HtCard>
-          {/*<div className="card" id="login-card">*/}
-          {/*  <h4 className="card-header bg-primary text-light">Login</h4>*/}
-          {/*  <div className="card-body">*/}
-          {/*    <HtForm onSubmit={handleSubmit(onSubmit)}>*/}
-          {/*      <HtForm.Group>*/}
-          {/*        <HtForm.Label htmlFor="username">Username</HtForm.Label>*/}
-          {/*        <Form.Control*/}
-          {/*          id="username"*/}
-          {/*          type="text"*/}
-          {/*          placeholder={'wary-walrus-123'}*/}
-          {/*          {...register('username', {})}*/}
-          {/*          className={errors.username && 'is-invalid'}*/}
-          {/*        />*/}
-          {/*        <div className="invalid-feedback">{errors.username?.message}</div>*/}
-          {/*      </HtForm.Group>*/}
-          {/*      <HtForm.Group>*/}
-          {/*        <HtForm.Label htmlFor="password">Password</HtForm.Label>*/}
-          {/*        <Form.Control*/}
-          {/*          id="password"*/}
-          {/*          type="password"*/}
-          {/*          placeholder="MyP@ssword123"*/}
-          {/*          {...register('password', {})}*/}
-          {/*          className={errors.password && 'is-invalid'}*/}
-          {/*        />*/}
-          {/*        <div className="invalid-feedback">{errors.password?.message}</div>*/}
-          {/*      </HtForm.Group>*/}
-          {/*      <button type="submit" disabled={isSubmitting} className="btn btn-primary m-2">*/}
-          {/*        {isSubmitting && <span className="spinner-border spinner-border-sm mr-1" />}*/}
-          {/*        Login*/}
-          {/*      </button>*/}
-          {/*      {authError && <div className="alert alert-danger mt-3 mb-0">{authError}</div>}*/}
-          {/*    </HtForm>*/}
-          {/*  </div>*/}
-          {/*</div>*/}
         </Row>
       </Col>
     </Container>

--- a/client/src/features/manifest/NewManifest.tsx
+++ b/client/src/features/manifest/NewManifest.tsx
@@ -9,13 +9,13 @@ import { Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { useAppSelector } from 'store';
-import { getSiteByEpaId } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { siteByEpaIdSelector } from 'store/rcraProfileSlice/rcraProfile.slice';
 
 export function NewManifest() {
   useTitle('New Manifest');
   const { siteId } = useParams();
   const { control } = useForm();
-  const rcraSite = useAppSelector(getSiteByEpaId(siteId));
+  const rcraSite = useAppSelector(siteByEpaIdSelector(siteId));
   const [manifestingSite, setManifestingSite] = useState<RcraSite | undefined | null>(rcraSite);
   const [manifestingSiteType, setManifestingSiteType] = useState<RcraSiteType | undefined>(
     manifestingSite?.siteType === 'Generator' ? manifestingSite.siteType : undefined

--- a/client/src/features/notifications/Notifications.tsx
+++ b/client/src/features/notifications/Notifications.tsx
@@ -6,7 +6,7 @@ import { useTitle } from 'hooks';
 import React from 'react';
 import { Col, Container, Table } from 'react-bootstrap';
 import { useAppSelector } from 'store';
-import { NotificationState } from 'store/notificationSlice/notification.slice';
+import { HtNotification, selectNotifications } from 'store/notificationSlice/notification.slice';
 
 /**
  * Table showing the user's current notifications
@@ -14,7 +14,7 @@ import { NotificationState } from 'store/notificationSlice/notification.slice';
  */
 export function Notifications() {
   useTitle('Notifications');
-  const notificationState: NotificationState = useAppSelector((state) => state.notification);
+  const notifications: Array<HtNotification> = useAppSelector(selectNotifications);
 
   return (
     <>
@@ -23,7 +23,7 @@ export function Notifications() {
           <HtCard>
             <HtCard.Header title="Notifications"></HtCard.Header>
             <HtCard.Body>
-              {notificationState.notifications.length === 0 ? (
+              {notifications.length === 0 ? (
                 <div className="text-center">
                   <h3>Nothing to see here, you're all caught up!</h3>
                   <FontAwesomeIcon className="text-info" icon={faFaceSmile} size={'6x'} />
@@ -39,7 +39,7 @@ export function Notifications() {
                     </tr>
                   </thead>
                   <tbody>
-                    {notificationState.notifications.map((notification) => {
+                    {notifications.map((notification) => {
                       return (
                         <NotificationRow key={notification.uniqueId} notification={notification} />
                       );

--- a/client/src/features/profile/Profile.tsx
+++ b/client/src/features/profile/Profile.tsx
@@ -5,8 +5,7 @@ import { useTitle } from 'hooks';
 import React, { ReactElement, useEffect } from 'react';
 import { Col, Container, Row } from 'react-bootstrap';
 import { useAppDispatch, useAppSelector } from 'store';
-import { getProfile } from 'store/rcraProfileSlice';
-import { RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { getProfile, selectRcraProfile } from 'store/rcraProfileSlice';
 
 /**
  * Display user profile
@@ -14,7 +13,7 @@ import { RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
  */
 export function Profile(): ReactElement {
   const dispatch = useAppDispatch();
-  const profile = useAppSelector<RcraProfileState>((state) => state.rcraProfile);
+  const profile = useAppSelector(selectRcraProfile);
   useTitle('Profile');
 
   useEffect(() => {

--- a/client/src/store/notificationSlice/index.ts
+++ b/client/src/store/notificationSlice/index.ts
@@ -2,9 +2,10 @@ import notificationReducer, {
   addNotification,
   removeNotification,
   updateNotification,
+  selectNotifications,
 } from 'store/notificationSlice/notification.slice';
 import Notification from './notification.slice';
 
 export default notificationReducer;
-export { addNotification, removeNotification, updateNotification };
+export { addNotification, removeNotification, updateNotification, selectNotifications };
 export type { Notification };

--- a/client/src/store/notificationSlice/notification.slice.ts
+++ b/client/src/store/notificationSlice/notification.slice.ts
@@ -89,6 +89,9 @@ const notificationSlice = createSlice({
   },
 });
 
+export const selectNotifications = (state: { notification: NotificationState }) =>
+  state.notification.notifications;
+
 export default notificationSlice.reducer;
 export const { addNotification, removeNotification, updateNotification } =
   notificationSlice.actions;

--- a/client/src/store/rcraProfileSlice/index.ts
+++ b/client/src/store/rcraProfileSlice/index.ts
@@ -1,4 +1,17 @@
 import rcraProfileReducers, { getProfile, updateProfile } from './rcraProfile.slice';
+import {
+  selectRcraSites,
+  userSiteSelector,
+  selectRcraProfile,
+  getSiteByEpaId,
+} from './rcraProfile.slice';
 
 export default rcraProfileReducers;
-export { getProfile, updateProfile };
+export {
+  getProfile,
+  updateProfile,
+  selectRcraProfile,
+  userSiteSelector,
+  selectRcraSites,
+  getSiteByEpaId,
+};

--- a/client/src/store/rcraProfileSlice/index.ts
+++ b/client/src/store/rcraProfileSlice/index.ts
@@ -1,9 +1,9 @@
 import rcraProfileReducers, { getProfile, updateProfile } from './rcraProfile.slice';
 import {
   selectRcraSites,
-  userSiteSelector,
+  userRcraSitesSelector,
   selectRcraProfile,
-  getSiteByEpaId,
+  siteByEpaIdSelector,
 } from './rcraProfile.slice';
 
 export default rcraProfileReducers;
@@ -11,7 +11,7 @@ export {
   getProfile,
   updateProfile,
   selectRcraProfile,
-  userSiteSelector,
+  userRcraSitesSelector,
   selectRcraSites,
-  getSiteByEpaId,
+  siteByEpaIdSelector,
 };

--- a/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
+++ b/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
@@ -177,7 +177,7 @@ export const getSiteByEpaId = (epaId: string | undefined) =>
  * Retrieve a RcraSite that the user has access to in their RcraProfile by the site's EPA ID number
  * @param epaId
  */
-export const getUserSites = createSelector(
+export const selectUserSites = createSelector(
   (state: { rcraProfile: RcraProfileState }) => state.rcraProfile.rcraSites,
   (rcraSites: Record<string, RcraProfileSite> | undefined) => {
     if (!rcraSites) return undefined;

--- a/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
+++ b/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
@@ -155,7 +155,7 @@ const rcraProfileSlice = createSlice({
  * Retrieve a RcraSite that the user has access to in their RcraProfile by the site's EPA ID number
  * @param epaId
  */
-const getSiteByEpaId = (epaId: string | undefined) =>
+export const siteByEpaIdSelector = (epaId: string | undefined) =>
   createSelector(
     (state: { rcraProfile: RcraProfileState }) => state.rcraProfile.rcraSites,
     (rcraSites: Record<string, RcraProfileSite> | undefined) => {
@@ -173,13 +173,14 @@ const getSiteByEpaId = (epaId: string | undefined) =>
     }
   );
 
-const selectRcraSites = (state: { rcraProfile: RcraProfileState }) => state.rcraProfile.rcraSites;
+export const selectRcraSites = (state: { rcraProfile: RcraProfileState }) =>
+  state.rcraProfile.rcraSites;
 
 /**
  * Retrieve a RcraSite that the user has access to in their RcraProfile by the site's EPA ID number
  * @param epaId
  */
-const userSiteSelector = createSelector(
+export const userRcraSitesSelector = createSelector(
   selectRcraSites,
   (rcraSites: Record<string, RcraProfileSite> | undefined) => {
     if (!rcraSites) return undefined;
@@ -191,11 +192,10 @@ const userSiteSelector = createSelector(
 /**
  * Retrieve a user's RcraProfile from the Redux store
  */
-const selectRcraProfile = createSelector(
+export const selectRcraProfile = createSelector(
   (state: RootState) => state.rcraProfile,
   (rcraProfile: RcraProfileState) => rcraProfile
 );
 
 export default rcraProfileSlice.reducer;
 export const { updateProfile } = rcraProfileSlice.actions;
-export { selectRcraSites, userSiteSelector, selectRcraProfile, getSiteByEpaId };

--- a/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
+++ b/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
@@ -186,5 +186,13 @@ export const getUserSites = createSelector(
   }
 );
 
+/**
+ * Retrieve a user's RcraProfile from the Redux store
+ */
+export const selectRcraProfile = createSelector(
+  (state: RootState) => state.rcraProfile,
+  (rcraProfile: RcraProfileState) => rcraProfile
+);
+
 export default rcraProfileSlice.reducer;
 export const { updateProfile } = rcraProfileSlice.actions;

--- a/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
+++ b/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
@@ -155,7 +155,7 @@ const rcraProfileSlice = createSlice({
  * Retrieve a RcraSite that the user has access to in their RcraProfile by the site's EPA ID number
  * @param epaId
  */
-export const getSiteByEpaId = (epaId: string | undefined) =>
+const getSiteByEpaId = (epaId: string | undefined) =>
   createSelector(
     (state: { rcraProfile: RcraProfileState }) => state.rcraProfile.rcraSites,
     (rcraSites: Record<string, RcraProfileSite> | undefined) => {
@@ -173,12 +173,14 @@ export const getSiteByEpaId = (epaId: string | undefined) =>
     }
   );
 
+const selectRcraSites = (state: { rcraProfile: RcraProfileState }) => state.rcraProfile.rcraSites;
+
 /**
  * Retrieve a RcraSite that the user has access to in their RcraProfile by the site's EPA ID number
  * @param epaId
  */
-export const selectUserSites = createSelector(
-  (state: { rcraProfile: RcraProfileState }) => state.rcraProfile.rcraSites,
+const userSiteSelector = createSelector(
+  selectRcraSites,
   (rcraSites: Record<string, RcraProfileSite> | undefined) => {
     if (!rcraSites) return undefined;
 
@@ -189,10 +191,11 @@ export const selectUserSites = createSelector(
 /**
  * Retrieve a user's RcraProfile from the Redux store
  */
-export const selectRcraProfile = createSelector(
+const selectRcraProfile = createSelector(
   (state: RootState) => state.rcraProfile,
   (rcraProfile: RcraProfileState) => rcraProfile
 );
 
 export default rcraProfileSlice.reducer;
 export const { updateProfile } = rcraProfileSlice.actions;
+export { selectRcraSites, userSiteSelector, selectRcraProfile, getSiteByEpaId };

--- a/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
+++ b/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
@@ -11,8 +11,8 @@ import rcraProfileReducer, {
   getProfile,
   RcraProfileSite,
   RcraProfileState,
-  getSiteByEpaId,
-  userSiteSelector,
+  siteByEpaIdSelector,
+  userRcraSitesSelector,
 } from './rcraProfile.slice';
 
 const initialState: RcraProfileState = {
@@ -83,7 +83,7 @@ interface TestComponentProps {
 }
 
 function TestComponent({ siteId }: TestComponentProps) {
-  const rcraSite = useAppSelector(getSiteByEpaId(siteId));
+  const rcraSite = useAppSelector(siteByEpaIdSelector(siteId));
   return (
     <>
       <p>{rcraSite?.epaSiteId}</p>
@@ -114,7 +114,7 @@ describe('RcraProfileSlice selectors', () => {
   test('retrieve all RcraProfileSites', () => {
     const mySite = createMockSite();
     const TestComp = () => {
-      const myRcraSite = useAppSelector(userSiteSelector);
+      const myRcraSite = useAppSelector(userRcraSitesSelector);
       return (
         <>
           <p>{myRcraSite ? Object.keys(myRcraSite).length : 'not defined'}</p>

--- a/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
+++ b/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
@@ -12,7 +12,7 @@ import rcraProfileReducer, {
   RcraProfileSite,
   RcraProfileState,
   getSiteByEpaId,
-  getUserSites,
+  selectUserSites,
 } from './rcraProfile.slice';
 
 const initialState: RcraProfileState = {
@@ -114,7 +114,7 @@ describe('RcraProfileSlice selectors', () => {
   test('retrieve all RcraProfileSites', () => {
     const mySite = createMockSite();
     const TestComp = () => {
-      const myRcraSite = useAppSelector(getUserSites);
+      const myRcraSite = useAppSelector(selectUserSites);
       return (
         <>
           <p>{myRcraSite ? Object.keys(myRcraSite).length : 'not defined'}</p>

--- a/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
+++ b/client/src/store/rcraProfileSlice/rcraProfileSlice.spec.tsx
@@ -12,7 +12,7 @@ import rcraProfileReducer, {
   RcraProfileSite,
   RcraProfileState,
   getSiteByEpaId,
-  selectUserSites,
+  userSiteSelector,
 } from './rcraProfile.slice';
 
 const initialState: RcraProfileState = {
@@ -114,7 +114,7 @@ describe('RcraProfileSlice selectors', () => {
   test('retrieve all RcraProfileSites', () => {
     const mySite = createMockSite();
     const TestComp = () => {
-      const myRcraSite = useAppSelector(selectUserSites);
+      const myRcraSite = useAppSelector(userSiteSelector);
       return (
         <>
           <p>{myRcraSite ? Object.keys(myRcraSite).length : 'not defined'}</p>

--- a/client/src/store/userSlice/index.ts
+++ b/client/src/store/userSlice/index.ts
@@ -1,4 +1,4 @@
-import userReducer, { login, selectUserName } from './user.slice';
+import userReducer, { login, selectUserName, selectUser } from './user.slice';
 
 export default userReducer;
-export { login, selectUserName };
+export { login, selectUserName, selectUser };

--- a/client/src/store/userSlice/index.ts
+++ b/client/src/store/userSlice/index.ts
@@ -1,4 +1,4 @@
-import userReducer, { login } from './user.slice';
+import userReducer, { login, selectUserName } from './user.slice';
 
 export default userReducer;
-export { login };
+export { login, selectUserName };

--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -91,4 +91,9 @@ const userSlice = createSlice({
  */
 export const selectUserName = (state: RootState) => state.user.user;
 
+/**
+ * Select the current user
+ */
+export const selectUser = (state: RootState) => state.user;
+
 export default userSlice.reducer;

--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -85,6 +85,7 @@ const userSlice = createSlice({
       });
   },
 });
+
 /**
  * Get the current user's username from the Redux store
  */

--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -89,7 +89,6 @@ const userSlice = createSlice({
 /**
  * Get the current user's username from the Redux store
  */
-const selectUserName = (state: RootState) => state.user.user;
+export const selectUserName = (state: RootState) => state.user.user;
 
 export default userSlice.reducer;
-export { selectUserName };

--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -85,6 +85,9 @@ const userSlice = createSlice({
       });
   },
 });
+/**
+ * Get the current user's username from the Redux store
+ */
 export const selectUserName = createSelector(
   (state: RootState) => state.user,
   (user: UserState) => user.user

--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -1,5 +1,7 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { RcraProfileSite, RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
+import { RootState } from 'store/rootStore';
 
 /**
  * The Redux stored information on the current haztrak user
@@ -83,5 +85,9 @@ const userSlice = createSlice({
       });
   },
 });
+export const selectUserName = createSelector(
+  (state: RootState) => state.user,
+  (user: UserState) => user.user
+);
 
 export default userSlice.reducer;

--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -89,9 +89,7 @@ const userSlice = createSlice({
 /**
  * Get the current user's username from the Redux store
  */
-export const selectUserName = createSelector(
-  (state: RootState) => state.user,
-  (user: UserState) => user.user
-);
+const selectUserName = (state: RootState) => state.user.user;
 
 export default userSlice.reducer;
+export { selectUserName };

--- a/docs/haztrak_book/src/design/browser-client.md
+++ b/docs/haztrak_book/src/design/browser-client.md
@@ -28,7 +28,8 @@ We use two naming conventions for selectors:
 
 ```typescript
 // Selects the `user` field from the state.
-import { useAppSelector } from 'src/store/hooks';
+import { useAppSelector } from 'store/hooks';
+import { selectUserName } from 'store/userSlice';
 
-const userName = useAppSelector(selectUser);
+const userName = useAppSelector(selectUserName);
 ```

--- a/docs/haztrak_book/src/design/browser-client.md
+++ b/docs/haztrak_book/src/design/browser-client.md
@@ -1,3 +1,34 @@
-# Client Architecture
+# Browser Client Architecture
 
 To Do, document our front end's design :)
+
+## Redux Store
+
+The redux store is the single source of truth for the client application. It contains
+state that's central to the operation of the application. For more information on redux,
+see the [redux documentation](https://redux.js.org/).
+
+### Naming Conventions
+
+For consist naming conventions, we've adopted the following:
+
+#### Selectors
+
+Selectors are functions that take the state as an argument and return some data from the state.
+They are used to encapsulate the state shape and allow us to change the state shape without having
+to change all the places where we access the state.
+
+We use two naming conventions for selectors:
+
+1. `select<StateField>` for selectors that return a single field from the state.
+2. `<stateField>Selector` for selectors that return a more complex data structure. Values are
+   memoized using the RTK's createSelector function.
+
+##### Examples
+
+```typescript
+// Selects the `user` field from the state.
+import { useAppSelector } from 'src/store/hooks';
+
+const userName = useAppSelector(selectUser);
+```

--- a/docs/haztrak_book/src/design/source-roadmap.md
+++ b/docs/haztrak_book/src/design/source-roadmap.md
@@ -38,9 +38,15 @@ directory.
 
 ## Notable Directories
 
-[`/server/apps/trak`](https://github.com/USEPA/haztrak/tree/main/server/apps/trak)
-This is a Django reusable app, it's self-encapsulating, it contains
-all the necessary models, serializers, views use electronic manifests.
+[`server/apps`](https://github.com/USEPA/haztrak/tree/main/server/apps/trak)
+This directory houses all our Django apps, really just for organizational purposes.
+
+[`server/apps/trak`](https://github.com/USEPA/haztrak/tree/main/server/apps/trak)
+A Django reusable app that contains models related to hazardous waste tracking (electronic manifests)
+It depends on the `sites` app, the Handler model contains a foreign key to the RcraSite model (many-to-one relationship).
+
+[`server/apps/sites`](https://github.com/USEPA/haztrak/tree/main/server/apps/trak)
+A Django reusable app that contains models related to RCRAInfo sites.
 
 [`client/src/features`](https://github.com/USEPA/haztrak/tree/main/client/src/features)
 This directory, theoretically, contains the high level logic for

--- a/server/apps/trak/models/manifest_models.py
+++ b/server/apps/trak/models/manifest_models.py
@@ -11,9 +11,9 @@ from apps.sites.models import RcraSiteType, RcraStates
 from apps.trak.models import Handler
 
 from .base_models import TrakBaseManager, TrakBaseModel
+from .signature_models import ESignature
 from .transporter_models import Transporter
 from .waste_models import WasteLine
-from .signature_models import ESignature
 
 logger = logging.getLogger(__name__)
 
@@ -404,6 +404,7 @@ class ImportInfo(TrakBaseModel):
         null=True,
         blank=True,
     )
+
 
 class CorrectionInfo(TrakBaseModel):
     """


### PR DESCRIPTION
## Description

This PR introduces real selectors into our project (something that should have been done a LONG time ago) so our redux state is encapsulated and the details remain hidden/abstracted from our components. This way we can change the structure of our redux state without having to change all our components that rely on that state.  

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
closes #470


## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
