### PR TITLE
516 navigation icon location

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -16,6 +16,13 @@ $info: #009999;
   left: -0.25rem !important;
 }
 
+.btn-hover-info {
+  &:hover {
+    background-color: $info !important;
+    color: white !important;
+  }
+}
+
 // Custom Pagination
 .page-item .page-link {
   background: white;

--- a/client/src/components/Nav/TopNav.tsx
+++ b/client/src/components/Nav/TopNav.tsx
@@ -25,7 +25,16 @@ export function TopNav() {
   // noinspection JSValidateTypes
   return (
     <nav className="sb-topnav navbar navbar-expand navbar-dark bg-dark d-flex">
-      <div className="flex-grow-1 ps-2">
+      <div className="flex-grow-1">
+        <Button
+          aria-label="toggleSidebarNavigation"
+          aria-hidden={false}
+          id="sidebarToggle"
+          onClick={toggleSidebar}
+          className="mx-3 btn-link btn btn-sm bg-transparent btn-outline-none btn-outline-dark"
+        >
+          <FontAwesomeIcon icon={faBars} />
+        </Button>
         <Link to="/" className="navbar-brand ps-3 pe-5">
           <img
             src={logo}
@@ -35,15 +44,6 @@ export function TopNav() {
             className="my-3"
           />
         </Link>
-        <Button
-          aria-label="toggleSidebarNavigation"
-          aria-hidden={false}
-          id="sidebarToggle"
-          onClick={toggleSidebar}
-          className="ms-5 btn-link btn btn-sm bg-transparent btn-outline-none btn-outline-dark"
-        >
-          <FontAwesomeIcon icon={faBars} />
-        </Button>
       </div>
       <NotificationBtn />
       <ul className="navbar-nav ms-auto ms-md-0 me-3 me-lg-4">

--- a/client/src/components/Nav/TopNav.tsx
+++ b/client/src/components/Nav/TopNav.tsx
@@ -31,7 +31,8 @@ export function TopNav() {
           aria-hidden={false}
           id="sidebarToggle"
           onClick={toggleSidebar}
-          className="mx-3 btn-link btn btn-sm bg-transparent btn-outline-none btn-outline-dark"
+          variant="dark"
+          className="mx-3 rounded-circle btn-hover-info"
         >
           <FontAwesomeIcon icon={faBars} />
         </Button>

--- a/runhaz.sh
+++ b/runhaz.sh
@@ -133,6 +133,10 @@ while [[ $# -gt 0 ]]; do
     -e|--erd)
 	  graph_models
 		;;
+    -h|--help)
+	  print_usage
+    exit 0
+		;;
     *)
       echo "Unknown option $1"
 	  print_usage


### PR DESCRIPTION
## Description

This PR modifies our sidebar navigation toggle button by moving it to a location that a user would  expect it to be at instead of floating around in the middle of the top navigation bar. It takes inspiration from the google cloud console (also, it just didn't really make an sesne where it was before).

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->

closes #516 

## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
