### PR TITLE
remove text-muted from notification icon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: 'monthly'
     labels:
-      - 'reactjs'
+      - 'client'
       - 'dependencies'
     open-pull-requests-limit: 2
     reviewers:
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: 'monthly'
     labels:
-      - 'django'
+      - 'server'
       - 'dependencies'
     open-pull-requests-limit: 2
     reviewers:

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -16,9 +16,9 @@ $info: #009999;
   left: -0.25rem !important;
 }
 
-.btn-hover-info {
+.btn-hover-dark {
   &:hover {
-    background-color: $info !important;
+    background-color: #333333 !important;
     color: white !important;
   }
 }

--- a/client/src/components/Nav/TopNav.tsx
+++ b/client/src/components/Nav/TopNav.tsx
@@ -32,7 +32,7 @@ export function TopNav() {
           id="sidebarToggle"
           onClick={toggleSidebar}
           variant="dark"
-          className="mx-3 rounded-circle btn-hover-info"
+          className="mx-3 rounded-circle btn-hover-dark"
         >
           <FontAwesomeIcon icon={faBars} />
         </Button>
@@ -47,7 +47,7 @@ export function TopNav() {
         </Link>
       </div>
       <NotificationBtn />
-      <ul className="navbar-nav ms-auto ms-md-0 me-3 me-lg-4">
+      <ul className="navbar-nav ms-auto ms-md-0 me-3 me-lg-4 btn-hover-dark rounded-circle">
         <li className="nav-item dropdown">
           <Dropdown>
             <Dropdown.Toggle

--- a/client/src/components/Notification/NotificationBtn.tsx
+++ b/client/src/components/Notification/NotificationBtn.tsx
@@ -11,11 +11,14 @@ export function NotificationBtn() {
   const numberAlerts = notifications.length;
   const alertsExists: boolean = numberAlerts > 0;
 
+  console.log(alertsExists);
   return (
     <div className="mx-3 px-2 position-relative d-inline-block">
       <Link to={'/notifications'}>
         <Button
-          className={`bg-transparent border-0 ${alertsExists ? 'text-primary' : 'text-muted'}`}
+          className={`bg-transparent border-0 btn-hover-dark rounded-circle ${
+            alertsExists ? 'text-primary' : 'text-secondary'
+          }`}
         >
           <div>
             <FontAwesomeIcon icon={faEnvelope} size="lg" />


### PR DESCRIPTION
## Description

This is a quick fix for the notification icon that disappeared when there were not notifications. 


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
closes #515 

## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
