### PR TITLE
Waste line schema and cosmetics

### DIFF
--- a/client/src/components/Manifest/WasteLine/QuantityForm.tsx
+++ b/client/src/components/Manifest/WasteLine/QuantityForm.tsx
@@ -1,4 +1,6 @@
+import { ErrorMessage } from '@hookform/error-message';
 import { HtForm } from 'components/Ht';
+import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -32,7 +34,11 @@ const containerTypes = [
 ];
 
 export function QuantityForm() {
-  const { register, control } = useFormContext();
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext<WasteLine>();
 
   return (
     <>
@@ -44,7 +50,9 @@ export function QuantityForm() {
               type="number"
               min={1}
               {...register(`quantity.containerNumber`, { min: 0, valueAsNumber: true })}
+              className={errors.quantity?.containerNumber && 'is-invalid'}
             />
+            <div className="invalid-feedback">{errors.quantity?.containerNumber?.message}</div>
           </HtForm.Group>
         </Col>
         <Col>
@@ -59,14 +67,29 @@ export function QuantityForm() {
                 return (
                   <Select
                     id="quantityContainerType"
+                    classNames={{
+                      control: () =>
+                        `form-control p-0 rounded-2 ${
+                          errors.quantity?.containerType && 'border-danger'
+                        }`,
+                    }}
                     {...field}
+                    // ToDo: WasteLine type expects a string enum literal as its possible values.
+                    // ToDo: Fix these minor typescript errors
+                    // @ts-ignore
                     options={containerTypes}
+                    // @ts-ignore
                     getOptionLabel={(option) => option.description}
                     getOptionValue={(option) => option.code}
                     openMenuOnFocus={false}
                   />
                 );
               }}
+            />
+            <ErrorMessage
+              errors={errors}
+              name={`quantity.containerType`}
+              render={({ message }) => <span className="text-danger">{message}</span>}
             />
           </HtForm.Group>
         </Col>
@@ -81,7 +104,9 @@ export function QuantityForm() {
               {...register(`quantity.quantity`, {
                 valueAsNumber: true,
               })}
+              className={errors.quantity?.quantity && 'is-invalid'}
             />
+            <div className="invalid-feedback">{errors.quantity?.quantity?.message}</div>
           </HtForm.Group>
         </Col>
         <Col>
@@ -97,13 +122,28 @@ export function QuantityForm() {
                   <Select
                     id="quantityUnitOfMeasurement"
                     {...field}
+                    // ToDo: WasteLine type expects a string enum literal as its possible values.
+                    // ToDo: Fix these minor typescript errors
+                    // @ts-ignore
                     options={unitsOfMeasurements}
+                    // @ts-ignore
                     getOptionLabel={(option) => option.description}
                     getOptionValue={(option) => option.code}
                     openMenuOnFocus={false}
+                    classNames={{
+                      control: () =>
+                        `form-control p-0 rounded-2 ${
+                          errors.quantity?.unitOfMeasurement && 'border-danger'
+                        } `,
+                    }}
                   />
                 );
               }}
+            />
+            <ErrorMessage
+              errors={errors}
+              name={`quantity.unitOfMeasurement`}
+              render={({ message }) => <span className="text-danger">{message}</span>}
             />
           </HtForm.Group>
         </Col>

--- a/client/src/components/Manifest/WasteLine/QuantityForm.tsx
+++ b/client/src/components/Manifest/WasteLine/QuantityForm.tsx
@@ -39,9 +39,10 @@ export function QuantityForm() {
       <Row className="mb-2">
         <Col xs={3}>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0">Container Number</HtForm.Label>
+            <HtForm.Label className="mb-0">Number</HtForm.Label>
             <Form.Control
               type="number"
+              min={1}
               {...register(`quantity.containerNumber`, { min: 0, valueAsNumber: true })}
             />
           </HtForm.Group>
@@ -73,11 +74,11 @@ export function QuantityForm() {
       <Row>
         <Col xs={3}>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0">Total Quantity</HtForm.Label>
+            <HtForm.Label className="mb-0">Quantity</HtForm.Label>
             <Form.Control
               type="number"
+              min={1}
               {...register(`quantity.quantity`, {
-                min: 0,
                 valueAsNumber: true,
               })}
             />

--- a/client/src/components/Manifest/WasteLine/WasteLineForm.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineForm.tsx
@@ -1,3 +1,4 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { HtCard, HtForm } from 'components/Ht';
 import { AdditionalInfoForm } from 'components/AdditionalInfo/AdditionalInfoForm';
 import { HazardousWasteForm } from './HazardousWasteForm';
@@ -5,7 +6,7 @@ import React from 'react';
 import { Button, Container, Form, Row } from 'react-bootstrap';
 import { FormProvider, UseFieldArrayAppend, useForm } from 'react-hook-form';
 import { Manifest } from 'components/Manifest/manifestSchema';
-import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
+import { WasteLine, wasteLineSchema } from 'components/Manifest/WasteLine/wasteLineSchema';
 import { QuantityForm } from './QuantityForm';
 
 interface WasteLineFormProps {
@@ -14,21 +15,36 @@ interface WasteLineFormProps {
   appendWaste: UseFieldArrayAppend<Manifest, 'wastes'>;
 }
 
+const wasteLineDefaultValues: Partial<WasteLine> = {
+  dotHazardous: true,
+  epaWaste: false,
+  // @ts-ignore
+  quantity: { containerNumber: 1, quantity: 1 },
+};
+
 /**
  * WasteLineForm is the top level component/form for adding wastes to
  * the uniform hazardous waste manifest.
  * @constructor
  */
-export function WasteLineForm({ handleClose, appendWaste }: WasteLineFormProps) {
-  // ToDo: on submit, add new WasteLine object to the ManifestForm. we'll need
-  //  to add another useFieldArray hook for the 'wastes' field in the Manifest
-  //  and pass the necessary methods to this component (like we did the TransporterForm)
+export function WasteLineForm({ handleClose, appendWaste, currentWastes }: WasteLineFormProps) {
+  const newLineNumber = currentWastes ? currentWastes.length + 1 : 1;
+  const wasteMethods = useForm<WasteLine>({
+    resolver: zodResolver(wasteLineSchema),
+    defaultValues: { ...wasteLineDefaultValues, lineNumber: newLineNumber },
+  });
+  const { register, handleSubmit } = wasteMethods;
+
+  console.log(wasteMethods.formState.errors);
+
+  /**
+   * onSubmit is the callback function for the form submission.
+   * @param data
+   */
   const onSubmit = (data: WasteLine) => {
-    appendWaste(data);
+    appendWaste(data); // append the new waste line to the manifest
     handleClose();
   };
-  const wasteMethods = useForm<WasteLine>();
-  const { register, handleSubmit } = wasteMethods;
 
   return (
     <FormProvider {...wasteMethods}>

--- a/client/src/components/Manifest/WasteLine/WasteLineForm.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineForm.tsx
@@ -35,14 +35,13 @@ export function WasteLineForm({ handleClose, appendWaste, currentWastes }: Waste
   });
   const { register, handleSubmit } = wasteMethods;
 
-  console.log(wasteMethods.formState.errors);
-
   /**
    * onSubmit is the callback function for the form submission.
-   * @param data
+   * @param wasteLine the data submitted from the form
    */
-  const onSubmit = (data: WasteLine) => {
-    appendWaste(data); // append the new waste line to the manifest
+  const onSubmit = (wasteLine: WasteLine) => {
+    console.log('wasteline', wasteLine);
+    appendWaste(wasteLine); // append the new waste line to the manifest
     handleClose();
   };
 

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -34,7 +34,6 @@ export function WasteLineTable({ wastes }: WasteLineTableProps) {
           return (
             <tr key={index}>
               <td>{wasteLine.lineNumber}</td>
-              {/*<td>{wasteLine.wasteDescription}</td>*/}
               <td
                 style={{
                   maxWidth: '200px',
@@ -48,14 +47,18 @@ export function WasteLineTable({ wastes }: WasteLineTableProps) {
               <td>{wasteLine.quantity?.containerNumber}</td>
               <td>{String(wasteLine.quantity?.containerType.code)}</td>
               <td>
-                <small>
-                  {wasteLine.hazardousWaste?.federalWasteCodes?.map((code, index) => {
-                    // ToDo: fix how hazardous waste codes are appended to wasteline
-                    // @ts-ignore
-                    return `${String(code.value)} ${
-                      index + 1 === wasteLine.hazardousWaste?.federalWasteCodes?.length ? ' ' : ', '
-                    }`;
-                  })}
+                <small
+                  style={{
+                    display: '-webkit-box',
+                    maxHeight: '60px',
+                    maxWidth: '100px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    WebkitBoxOrient: 'vertical',
+                    WebkitLineClamp: 2,
+                  }}
+                >
+                  {wasteLine.hazardousWaste?.federalWasteCodes?.map((item) => item.code).join(', ')}
                 </small>
               </td>
               <td className="text-center">

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -1,3 +1,5 @@
+import { faTools } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Table } from 'react-bootstrap';
 import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
@@ -24,7 +26,7 @@ export function WasteLineTable({ wastes }: WasteLineTableProps) {
           <th>Containers</th>
           <th>Type</th>
           <th>Codes</th>
-          <th>Actions</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -34,7 +36,7 @@ export function WasteLineTable({ wastes }: WasteLineTableProps) {
               <td>{wasteLine.lineNumber}</td>
               <td>{wasteLine.wasteDescription}</td>
               <td>{wasteLine.quantity?.containerNumber}</td>
-              <td>{String(wasteLine.quantity?.containerType)}</td>
+              <td>{String(wasteLine.quantity?.containerType.code)}</td>
               <td>
                 <small>
                   {wasteLine.hazardousWaste?.federalWasteCodes?.map((code, index) => {
@@ -46,8 +48,8 @@ export function WasteLineTable({ wastes }: WasteLineTableProps) {
                   })}
                 </small>
               </td>
-              <td>
-                <p>ToDo</p>
+              <td className="text-center">
+                <FontAwesomeIcon icon={faTools} className="text-info" />
               </td>
             </tr>
           );

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -34,7 +34,17 @@ export function WasteLineTable({ wastes }: WasteLineTableProps) {
           return (
             <tr key={index}>
               <td>{wasteLine.lineNumber}</td>
-              <td>{wasteLine.wasteDescription}</td>
+              {/*<td>{wasteLine.wasteDescription}</td>*/}
+              <td
+                style={{
+                  maxWidth: '200px',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {wasteLine.wasteDescription}
+              </td>
               <td>{wasteLine.quantity?.containerNumber}</td>
               <td>{String(wasteLine.quantity?.containerType.code)}</td>
               <td>

--- a/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
+++ b/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
@@ -1,3 +1,46 @@
+import { z } from 'zod';
+
+enum ContainerDescription {
+  BA = 'Burlap, cloth, paper, or plastic bags',
+  DT = 'Dump truck',
+  CF = 'Fiber or plastic boxes, cartons, cases',
+  DW = 'Wooden drums, barrels, kegs',
+  CM = 'Metal boxes, cartons, cases (including roll offs)',
+  HG = 'Hopper or gondola cars',
+  CW = 'Wooden boxes, cartons, cases',
+  TC = 'Tank cars',
+  CY = 'Cylinders',
+  TP = 'Portable tanks',
+  DF = 'Fiberboard or plastic drums, barrels, kegs',
+  TT = 'Cargo tanks (tank trucks)',
+  DM = 'Metal drums, barrels, kegs',
+}
+
+export const containerTypeSchema = z.object({
+  code: z.enum(['BA', 'DT', 'CF', 'DW', 'CM', 'HG', 'CW', 'TC', 'CY', 'TP', 'DF', 'TT', 'DM']),
+  description: z.string().optional(),
+});
+
+export const quantityUOMSchema = z.object({
+  code: z.enum(['P', 'T', 'K', 'M', 'G', 'L', 'Y', 'N']),
+  description: z.string().optional(),
+});
+
+const quantitySchema = z.object({
+  containerNumber: z.number(),
+  containerType: containerTypeSchema,
+  quantity: z.number(),
+  unitOfMeasurement: quantityUOMSchema,
+});
+
+export const wasteLineSchema = z.object({
+  lineNumber: z.number(),
+  dotHazardous: z.boolean(),
+  epaWaste: z.boolean(),
+  pcb: z.boolean(),
+  quantity: quantitySchema,
+});
+
 /**
  * Represents waste information captures on EPA's hazardous waste manifest
  */
@@ -86,22 +129,6 @@ enum QuantityDescription {
 interface ContainerType {
   code: 'BA' | 'DT' | 'CF' | 'DW' | 'CM' | 'HG' | 'CW' | 'TC' | 'CY' | 'TP' | 'DF' | 'TT' | 'DM';
   description?: ContainerDescription;
-}
-
-enum ContainerDescription {
-  BA = 'Burlap, cloth, paper, or plastic bags',
-  DT = 'Dump truck',
-  CF = 'Fiber or plastic boxes, cartons, cases',
-  DW = 'Wooden drums, barrels, kegs',
-  CM = 'Metal boxes, cartons, cases (including roll offs)',
-  HG = 'Hopper or gondola cars',
-  CW = 'Wooden boxes, cartons, cases',
-  TC = 'Tank cars',
-  CY = 'Cylinders',
-  TP = 'Portable tanks',
-  DF = 'Fiberboard or plastic drums, barrels, kegs',
-  TT = 'Cargo tanks (tank trucks)',
-  DM = 'Metal drums, barrels, kegs',
 }
 
 interface HazardousWaste {

--- a/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
+++ b/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
@@ -33,33 +33,62 @@ const quantitySchema = z.object({
   unitOfMeasurement: quantityUOMSchema,
 });
 
+const codeSchema = z.object({
+  code: z.string(),
+  description: z.string().optional(),
+});
+
+/**
+ * EPA defined generic interface for codes of various types and their description
+ * such as density UOM, waste codes, form codes, and more.
+ */
+export type Code = z.infer<typeof codeSchema>;
+
+const hazardousWasteSchema = z.object({
+  federalWasteCodes: z.array(codeSchema).optional(),
+  tsdfStateWasteCodes: z.array(codeSchema).optional(),
+  txWasteCodes: z.string().optional(),
+  generatorStateWasteCodes: z.array(codeSchema).optional(),
+});
+
 export const wasteLineSchema = z.object({
   lineNumber: z.number(),
   dotHazardous: z.boolean(),
   epaWaste: z.boolean(),
   pcb: z.boolean(),
+  dotInformation: z.any().optional(),
+  wasteDescription: z.string().optional(),
   quantity: quantitySchema,
+  brInfo: z.any().optional(),
+  br: z.boolean(),
+  hazardousWaste: hazardousWasteSchema.optional(),
+  pcbInfos: z.any().optional(),
+  discrepancyResidueInfo: z.any().optional(),
+  managementMethod: z.any().optional(),
+  additionalInfo: z.any().optional(),
 });
 
-/**
- * Represents waste information captures on EPA's hazardous waste manifest
- */
-interface WasteLine {
-  dotHazardous: boolean;
-  epaWaste: boolean;
-  pcb: boolean;
-  lineNumber: number;
-  dotInformation?: DotInformation;
-  wasteDescription?: string;
-  quantity?: Quantity;
-  brInfo?: BrInfo;
-  br: boolean;
-  hazardousWaste?: HazardousWaste;
-  pcbInfos?: PcbInfo[];
-  discrepancyResidueInfo?: DiscrepancyResidueInfo;
-  managementMethod?: Code;
-  additionalInfo?: AdditionalInfo;
-}
+export type WasteLine = z.infer<typeof wasteLineSchema>;
+
+// /**
+//  * Represents waste information captures on EPA's hazardous waste manifest
+//  */
+// interface WasteLine {
+//   dotHazardous: boolean;
+//   epaWaste: boolean;
+//   pcb: boolean;
+//   lineNumber: number;
+//   dotInformation?: DotInformation;
+//   wasteDescription?: string;
+//   quantity?: Quantity;
+//   brInfo?: BrInfo;
+//   br: boolean;
+//   hazardousWaste?: HazardousWaste;
+//   pcbInfos?: PcbInfo[];
+//   discrepancyResidueInfo?: DiscrepancyResidueInfo;
+//   managementMethod?: Code;
+//   additionalInfo?: AdditionalInfo;
+// }
 
 /**
  * United States Department of Transportation (DOT) information
@@ -71,15 +100,6 @@ interface DotInformation {
    * RQ Description, Technical Name, Hazard Class, Packing Group and any user edits
    */
   printedDotInformation: string;
-}
-
-/**
- * EPA defined generic interface for codes of various types and their description
- * such as density UOM, waste codes, form codes, and more.
- */
-export interface Code {
-  code: string;
-  description?: string;
 }
 
 /**
@@ -169,4 +189,4 @@ interface Comment {
   handlerId: string;
 }
 
-export type { WasteLine, ContainerType, ContainerDescription, QuantityDescription };
+export type { ContainerType, ContainerDescription, QuantityDescription };

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -19,6 +19,9 @@ export const paperSignatureSchema = z.object({
   printedName: z.string(),
   signatureDate: z.string(),
 });
+
+export type PaperSignature = z.infer<typeof paperSignatureSchema>;
+
 /**
  * Schema for signer of a hazardous waste manifest
  */
@@ -74,7 +77,6 @@ export const transporterSchema = handlerSchema.extend({
  */
 export type Transporter = z.infer<typeof transporterSchema>;
 
-export type PaperSignature = z.infer<typeof paperSignatureSchema>;
 /**
  * A signer of a hazardous waste manifest
  */

--- a/client/src/components/Notification/NotificationBtn.tsx
+++ b/client/src/components/Notification/NotificationBtn.tsx
@@ -11,7 +11,6 @@ export function NotificationBtn() {
   const numberAlerts = notifications.length;
   const alertsExists: boolean = numberAlerts > 0;
 
-  console.log(alertsExists);
   return (
     <div className="mx-3 px-2 position-relative d-inline-block">
       <Link to={'/notifications'}>

--- a/client/src/features/profile/RcraProfile.tsx
+++ b/client/src/features/profile/RcraProfile.tsx
@@ -185,7 +185,6 @@ export function RcraProfile({ profile }: ProfileViewProps) {
             htApi
               .get(`profile/${profile.user}/sync`)
               .then((response) => {
-                console.log('data', response.data);
                 dispatch(
                   addNotification({
                     uniqueId: response.data.task,

--- a/client/src/test-utils/fixtures/mockWaste.ts
+++ b/client/src/test-utils/fixtures/mockWaste.ts
@@ -3,6 +3,12 @@ import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
 const DEFAULT_WASTELINE: WasteLine = {
   dotHazardous: false,
   epaWaste: true,
+  quantity: {
+    quantity: 1,
+    unitOfMeasurement: { code: 'P' },
+    containerNumber: 1,
+    containerType: { code: 'BA' },
+  },
   br: false,
   pcb: false,
   lineNumber: 1,


### PR DESCRIPTION
## Description

This PR replaces the typescript interface with the zod object schema for the wasteline. The `wasteLineSchema` object can be used for validation and as a type interface. 

We also make some small cosmetic changes to the `WasteLineTable` component.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 -->
closes #184 


## Checklist
<!-- We're happy your contributing! Help us by answering these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
