### PR TITLE
466 manifest must generator

### DIFF
--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -113,7 +113,7 @@ export function ManifestForm({
     manifestStatus === 'ReadyForSignature';
 
   // console.log(manifestData);
-  // if (errors) console.log('errors', errors);
+  if (errors) console.log('errors', errors);
 
   return (
     <>
@@ -381,7 +381,14 @@ export function ManifestForm({
               <ErrorMessage
                 errors={errors}
                 name={'generator'}
-                render={({ message }) => <span className="text-danger">{message}</span>}
+                render={({ message }) => {
+                  if (!message) return null;
+                  return (
+                    <Alert variant="danger" className="text-center m-3">
+                      {message}
+                    </Alert>
+                  );
+                }}
               />
             </HtCard.Body>
           </HtCard>

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -155,6 +155,11 @@ export const manifestSchema = z
     return true;
   })
   .refine(
+    // check that the manifest has a valid generator
+    (manifest) => manifest.generator !== undefined,
+    { path: ['generator'], message: 'Provide the site that generated this waste' }
+  )
+  .refine(
     // check that the manifest has at least 1 transporter
     (manifest) => manifest.transporters.length >= 1,
     { path: ['transporters'], message: 'A manifest requires at least 1 transporters' }


### PR DESCRIPTION
## Description

This small PR adds a refine method to our zod schema for the manfiest to check that a generator has been added. 

If a generator is not present, an error message (in the form of a bootstrap alert) will be displayed in the card asking the user to provide the site that generated the waste. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
fixes #466 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
