### PR TITLE
manifest must have wasteline

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,20 +40,15 @@ version-resolver:
 autolabeler:
   - label: 'server'
     files:
-      - 'server/**/*.py'
-    body:
-      - '/django/gmi'
+      - 'server/**/*'
+  - label: 'client'
+    files:
+      - 'client/**/*.{js,jsx,ts,tsx}'
   - label: 'test'
     files:
       - 'client/src/**/*.spec.{ts,tsx}'
       - 'server/**/test_*.py'
       - 'server/**/*_test.py'
-  - label: 'client'
-    files:
-      - 'client/**/*.{js,jsx,ts,tsx}'
-    body:
-      - '/react/gmi'
-      - '/redux/gmi'
   - label: 'infrastructure'
     files:
       - 'docker-compose.yaml'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,10 +40,15 @@ version-resolver:
 autolabeler:
   - label: 'server'
     files:
-      - 'server/**/*'
+      - '**/*.py'
+    body:
+      - '/django/gmi'
   - label: 'client'
     files:
-      - 'client/**/*.{js,jsx,ts,tsx}'
+      - '**/*.{js,jsx,ts,tsx}'
+    body:
+      - '/react/gmi'
+      - '/redux/gmi'
   - label: 'test'
     files:
       - 'client/src/**/*.spec.{ts,tsx}'

--- a/.github/workflows/test_client.yaml
+++ b/.github/workflows/test_client.yaml
@@ -18,21 +18,26 @@ jobs:
         working-directory: ./client
     strategy:
       matrix:
-        node: [16, 18]
+        node-version: [16, 18]
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
       - name: Install Dependencies
         run: npm ci
 
-      - name: Test Node.js-${{ matrix.node }}
+      - name: configure env
+        run: |
+          mv ../configs/.env.test .env
+          echo "VITE_HT_ENV=TEST" >> .env
+
+      - name: Test Node.js-${{ matrix.node-version }}
         run: npm test
         env:
           VITE_HT_ENV: 'TEST'

--- a/.idea/runConfigurations/Client.xml
+++ b/.idea/runConfigurations/Client.xml
@@ -7,8 +7,8 @@
     </scripts>
     <node-interpreter value="project" />
     <envs>
-      <env name="REACT_APP_HT_ENV" value="TEST" />
-      <env name="REACT_APP_HT_API_URL" value="http://localhost:8000" />
+      <env name="VITE_HT_API_URL" value="http://localhost:8000" />
+      <env name="VITE_HT_ENV" value="DEV" />
     </envs>
     <method v="2" />
   </configuration>

--- a/.idea/runConfigurations/Vitest_Run.xml
+++ b/.idea/runConfigurations/Vitest_Run.xml
@@ -5,7 +5,10 @@
     <vitest-package value="$PROJECT_DIR$/client/node_modules/vitest" />
     <working-dir value="$PROJECT_DIR$/client" />
     <vitest-options value="--run" />
-    <envs />
+    <envs>
+      <env name="VITE_HT_API_URL" value="http://localhost:8000" />
+      <env name="VITE_HT_ENV" value="DEV" />
+    </envs>
     <scope-kind value="ALL" />
     <method v="2" />
   </configuration>

--- a/.idea/runConfigurations/Vitest_Watch.xml
+++ b/.idea/runConfigurations/Vitest_Watch.xml
@@ -5,7 +5,10 @@
     <vitest-package value="$PROJECT_DIR$/client/node_modules/vitest" />
     <working-dir value="$PROJECT_DIR$/client" />
     <vitest-options value="--watch" />
-    <envs />
+    <envs>
+      <env name="VITE_HT_API_URL" value="http://localhost:8000" />
+      <env name="VITE_HT_ENV" value="DEV" />
+    </envs>
     <scope-kind value="ALL" />
     <method v="2" />
   </configuration>

--- a/client/src/components/Manifest/ManifestForm.spec.tsx
+++ b/client/src/components/Manifest/ManifestForm.spec.tsx
@@ -58,4 +58,12 @@ describe('ManifestForm validation', () => {
       await screen.findByText(/A manifest requires at least 1 transporters/i)
     ).toBeInTheDocument();
   });
+  test('at least one waste line is required', async () => {
+    renderWithProviders(<ManifestForm readOnly={false} />);
+    const saveBtn = screen.getByRole('button', { name: /Save/i });
+    await userEvent.click(saveBtn);
+    expect(
+      await screen.findByText(/A manifest requires at least 1 waste line/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -436,7 +436,11 @@ export function ManifestForm({
               <ErrorMessage
                 errors={errors}
                 name={'wastes'}
-                render={({ message }) => <span className="text-danger">{message}</span>}
+                render={({ message }) => (
+                  <Alert variant="danger" className="text-center m-3">
+                    {message}
+                  </Alert>
+                )}
               />
             </HtCard.Body>
           </HtCard>

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -160,6 +160,11 @@ export const manifestSchema = z
     { path: ['generator'], message: 'Generator is required' }
   )
   .refine(
+    // check that the manifest has at least 1 waste line
+    (manifest) => manifest.wastes.length >= 1,
+    { path: ['wastes'], message: 'A manifest requires at least 1 waste line' }
+  )
+  .refine(
     // check that the manifest has at least 1 transporter
     (manifest) => manifest.transporters.length >= 1,
     { path: ['transporters'], message: 'A manifest requires at least 1 transporters' }

--- a/client/src/features/home/Home.spec.tsx
+++ b/client/src/features/home/Home.spec.tsx
@@ -2,12 +2,31 @@ import '@testing-library/jest-dom';
 import { setupServer } from 'msw/node';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
-import { handlers } from 'test-utils/mock/handlers';
+import { API_BASE_URL, handlers } from 'test-utils/mock/handlers';
 import { Home } from 'features/home';
 import { vi } from 'vitest';
+import { rest } from 'msw';
 
-const server = setupServer(...handlers);
-const username = 'testuser1';
+const USERNAME = 'testuser1';
+
+const myAPIHandlers = [
+  rest.get(`${API_BASE_URL}/api/profile/${USERNAME}`, (req, res, ctx) => {
+    return res(
+      // Respond with a 200 status code
+      ctx.status(200),
+      ctx.json({
+        user: USERNAME,
+        rcraAPIID: 'mockRcraAPIID',
+        rcraUsername: undefined,
+        epaSites: [],
+        phoneNumber: undefined,
+        apiUser: true,
+      })
+    );
+  }),
+];
+
+const server = setupServer(...handlers, ...myAPIHandlers);
 
 beforeAll(() => server.listen()); // setup mock http server
 afterEach(() => {
@@ -22,7 +41,7 @@ describe('Home', () => {
     renderWithProviders(<Home />, {
       preloadedState: {
         user: {
-          user: { username: username, isLoading: false },
+          user: { username: USERNAME, isLoading: false },
           token: 'fake_token',
           loading: false,
           error: undefined,

--- a/client/src/features/home/Home.tsx
+++ b/client/src/features/home/Home.tsx
@@ -12,7 +12,7 @@ import { selectUserName } from 'store/userSlice/user.slice';
 import { HtButton, HtCard } from 'components/Ht';
 
 /**
- * Home page for logged-in user, currently does not really include anything
+ * Home page for logged-in user
  * @constructor
  */
 export function Home(): ReactElement {

--- a/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
+++ b/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
@@ -3,7 +3,6 @@
  * has access to for each EPA site ID.
  */
 import { createAsyncThunk, createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import axios from 'axios';
 import { HaztrakSite } from 'components/HaztrakSite';
 import { htApi } from 'services';
 import { RootState } from 'store';
@@ -97,7 +96,7 @@ export const getProfile = createAsyncThunk<RcraProfileState>(
   async (arg, thunkAPI) => {
     const state = thunkAPI.getState() as RootState;
     const username = state.user.user?.username;
-    const response = await htApi.get(`${import.meta.env.VITE_HT_API_URL}/api/profile/${username}`);
+    const response = await htApi.get(`/profile/${username}`);
     const { rcraSites, ...rest } = response.data as RcraProfileResponse;
     // Convert the array of RcraSite permissions we get from our backend
     // to an object which each key corresponding to the RcraSite's ID number

--- a/client/src/test-utils/mock/handlers.ts
+++ b/client/src/test-utils/mock/handlers.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { createMockHandler, createMockManifest, createMockSite } from '../fixtures';
 
-export const API_BASE_URL = import.meta.env.VITE_HT_API_URL;
+export const API_BASE_URL = 'http://localhost:8000';
 const mockMTN = createMockManifest().manifestTrackingNumber;
 const mockEpaId = createMockHandler().epaSiteId;
 const mockUsername = 'testuser1';

--- a/client/src/test-utils/mock/handlers.ts
+++ b/client/src/test-utils/mock/handlers.ts
@@ -1,7 +1,7 @@
 import { rest } from 'msw';
 import { createMockHandler, createMockManifest, createMockSite } from '../fixtures';
 
-export const API_BASE_URL = 'http://localhost:8000';
+export const API_BASE_URL = import.meta.env.VITE_HT_API_URL;
 const mockMTN = createMockManifest().manifestTrackingNumber;
 const mockEpaId = createMockHandler().epaSiteId;
 const mockUsername = 'testuser1';


### PR DESCRIPTION
## Description

This PR updates our manifest schema level validation so that users must supply at least 1 waste line before they can save a new manifest. 

The PR includes an error message (in the form of an alert) if at least 1 waste line is not provided 

![image](https://github.com/USEPA/haztrak/assets/43794491/b82ba935-7378-45b9-8f87-3c40333426c7)

outside of that, I've updated the .idea run configs to use the environment variables (specifically for mocking API calls). 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #467 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
