### PR TITLE
manifest must have tsdf

### DIFF
--- a/client/src/components/Manifest/ManifestForm.spec.tsx
+++ b/client/src/components/Manifest/ManifestForm.spec.tsx
@@ -66,4 +66,12 @@ describe('ManifestForm validation', () => {
       await screen.findByText(/A manifest requires at least 1 waste line/i)
     ).toBeInTheDocument();
   });
+  test('a TSDF is required', async () => {
+    renderWithProviders(<ManifestForm readOnly={false} />);
+    const saveBtn = screen.getByRole('button', { name: /Save/i });
+    await userEvent.click(saveBtn);
+    expect(
+      await screen.findByText(/Designated receiving facility is required/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -475,7 +475,14 @@ export function ManifestForm({
               <ErrorMessage
                 errors={errors}
                 name={'designatedFacility'}
-                render={({ message }) => <span className="text-danger">{message}</span>}
+                render={({ message }) => {
+                  if (!message) return null;
+                  return (
+                    <Alert variant="danger" className="text-center m-3">
+                      {message}
+                    </Alert>
+                  );
+                }}
               />
             </HtCard.Body>
           </HtCard>

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -160,6 +160,11 @@ export const manifestSchema = z
     { path: ['generator'], message: 'Generator is required' }
   )
   .refine(
+    // check that the manifest has a valid TSDF
+    (manifest) => manifest.designatedFacility !== undefined,
+    { path: ['designatedFacility'], message: 'Designated receiving facility is required' }
+  )
+  .refine(
     // check that the manifest has at least 1 waste line
     (manifest) => manifest.wastes.length >= 1,
     { path: ['wastes'], message: 'A manifest requires at least 1 waste line' }


### PR DESCRIPTION
## Description

This PR adds the validation (through the zod library) to check that a manifest has a valid tsdf provided before it can be successfully saved. Similar to what we added for the generator, transporter, and waste lines earlier today in #466. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #469 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
