### PR TITLE
Use postgres in workflow

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -3,8 +3,8 @@ name: 'Haztrak Server Tests'
 # It spins up a postgres container and runs the tests against it.
 
 env:
-  POSTGRES_USER: postgres
-  POSTGRES_PASSWORD: postgres
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: password1
   POSTGRES_DB: haztrak_db
 
 on:
@@ -36,6 +36,8 @@ jobs:
           POSTGRES_USER: ${{ env.POSTGRES_USER }}
           POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           POSTGRES_DB: ${{ env.POSTGRES_DB }}
+        ports:
+          - 5432/tcp
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -65,9 +67,10 @@ jobs:
           HT_RCRAINFO_ENV: preprod
           HT_DEBUG: true
           HT_DB_ENGINE: django.db.backends.postgresql
-          HT_DB_HOST: postgres
+          HT_DB_HOST: localhost
           HT_DB_USER: ${{ env.POSTGRES_USER }}
           HT_DB_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           HT_DB_NAME: ${{ env.POSTGRES_DB }}
+          HT_DB_PORT: ${{ job.services.postgres.ports[5432] }}
         run: |
           pytest

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -8,7 +8,6 @@ env:
   POSTGRES_DB: haztrak_db
 
 on:
-  push:
   pull_request:
     branches: ['main']
     paths:

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -3,11 +3,12 @@ name: 'Haztrak Server Tests'
 # It spins up a postgres container and runs the tests against it.
 
 env:
-  POSTGRES_USER: 'postgres'
+  POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
-  POSTGRES_DB: haztrak
+  POSTGRES_DB: haztrak_db
 
 on:
+  push:
   pull_request:
     branches: ['main']
     paths:
@@ -63,6 +64,8 @@ jobs:
           HT_HOST: localhost
           HT_RCRAINFO_ENV: preprod
           HT_DEBUG: true
+          HT_DB_ENGINE: django.db.backends.postgresql
+          HT_DB_HOST: localhost
           HT_DB_USER: ${{ env.POSTGRES_USER }}
           HT_DB_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           HT_DB_NAME: ${{ env.POSTGRES_DB }}

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -65,7 +65,7 @@ jobs:
           HT_RCRAINFO_ENV: preprod
           HT_DEBUG: true
           HT_DB_ENGINE: django.db.backends.postgresql
-          HT_DB_HOST: localhost
+          HT_DB_HOST: postgres
           HT_DB_USER: ${{ env.POSTGRES_USER }}
           HT_DB_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
           HT_DB_NAME: ${{ env.POSTGRES_DB }}

--- a/configs/.env.test
+++ b/configs/.env.test
@@ -8,7 +8,7 @@ HT_HOST=localhost
 HT_TIMEZONE=America/New_York
 HT_CORS_DOMAIN=http://localhost:3000
 HT_RCRAINFO_ENV=preprod
-HT_CACHE_URL=redis://redis:6379
+# HT_CACHE_URL=redis://redis:6379
 
 ### Logging
 HT_LOG_LEVEL=INFO
@@ -18,12 +18,13 @@ HT_LOG_FORMAT=verbose
 CELERY_LOG_LEVEL=INFO
 
 ### Django Database/ORM configs
-# we don't supply this during test, we're still using sqlite3 for testing
-# HT_DB_ENGINE=django.db.backends.postgresql
-# HT_DB_NAME=haztrak_db
-# HT_DB_USER=admin
-# HT_DB_PASSWORD='password1'
-# HT_DB_PORT=5432
+we don't supply this during test, we're still using sqlite3 for testing
+HT_DB_ENGINE=django.db.backends.postgresql
+HT_DB_NAME=haztrak_db
+HT_DB_USER=admin
+HT_DB_PASSWORD='password1'
+HT_DB_PORT=5432
+HT_DB_HOST=localhost
 
 ### Celery task queue configs
 CELERY_RESULT_BACKEND=django-db

--- a/runhaz.sh
+++ b/runhaz.sh
@@ -59,14 +59,16 @@ print_style() {
 }
 
 start_db(){
+    echo "starting database..."
+    # check if docker is installed
     if command -v docker> /dev/null 2>&1; then
         docker_exec=$(command -v docker)
     else
       print_style "Docker not found" "danger"
       exit 1
     fi
-    eval "$docker_exec compose --env-file $base_dir/configs/.env.dev up -d postgres"
-    exit
+    eval "$docker_exec compose -f $base_dir/docker-compose.yaml --env-file $base_dir/configs/.env.dev start postgres"
+    exit 0
 }
 
 load_django_fixtures() {
@@ -117,9 +119,7 @@ run_pre_commit() {
 while [[ $# -gt 0 ]]; do
   case $1 in
     -d|--db)
-        start_db "$@"
-#		shift # past argument
-#		shift # past value
+        start_db
         ;;
     -l|--load)
         load_django_fixtures

--- a/server/haztrak/settings.py
+++ b/server/haztrak/settings.py
@@ -108,7 +108,7 @@ DATABASES = {
         "HOST": os.environ.get("HT_DB_HOST", "localhost"),
         "PORT": os.environ.get("HT_DB_PORT", "5432"),
         "TEST": {
-            "NAME": BASE_DIR / "test_db.sqlite3",
+            "NAME": "test_db",
         },
     }
 }

--- a/server/haztrak/settings.py
+++ b/server/haztrak/settings.py
@@ -181,7 +181,7 @@ if os.getenv(CACHE_URL, None):
 else:
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
             "LOCATION": "./cache",
         }
     }


### PR DESCRIPTION
## Description

This PR makes minimal modifications to our test server workflow and configs to use postgres driver instead of the sqlite3. 

Digging into this has revealed more instability than I like to have in our development environment, my OCD is kicking in ha.

This PR also adds command line option to the `./runhaz` shell script to run the postgres database via docker compose. I'd like to expand (not necessarily just the shell script). I'd like to keep the test setup easy for newcomers so (if possible) new contributors don't have to worry about running a local database via docker. Further research pending, but right now it's friday and time to clock out.  

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #533 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
