### PR TITLE
fix draft manifest disabled status

### DIFF
--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -205,10 +205,7 @@ export function ManifestForm({
                     </HtForm.Label>
                     <HtForm.Select
                       id="submissionType"
-                      disabled={
-                        readOnly ||
-                        (manifestStatus !== 'NotAssigned' && manifestStatus !== 'Pending')
-                      }
+                      disabled={readOnly || !isDraft}
                       aria-label="submissionType"
                       {...manifestMethods.register('submissionType')}
                     >

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -167,12 +167,7 @@ export function ManifestForm({
                     </HtForm.Label>
                     <HtForm.Select
                       id="status"
-                      disabled={
-                        readOnly ||
-                        (manifestStatus !== 'NotAssigned' &&
-                          manifestStatus !== 'Pending' &&
-                          manifestStatus !== undefined)
-                      }
+                      disabled={readOnly || !isDraft}
                       aria-label="manifestStatus"
                       {...manifestMethods.register('status')}
                       onChange={(event) =>

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -49,6 +49,7 @@ export function ManifestForm({
       ...manifestData,
     };
   }
+  // React-Hook-Form methods and state
   const manifestMethods = useForm<Manifest>({
     values: values,
     resolver: zodResolver(manifestSchema),
@@ -59,8 +60,10 @@ export function ManifestForm({
   const [manifestStatus, setManifestStatus] = useState<ManifestStatus | undefined>(
     manifestData?.status
   );
-  useEffect(() => manifestMethods.setFocus('generator.epaSiteId'), []);
+  useEffect(() => manifestMethods.setFocus('status'), []);
   const navigate = useNavigate();
+
+  // Function to handle form submission
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
     console.log('Manifest Submitted', data);
   };
@@ -114,6 +117,8 @@ export function ManifestForm({
     manifestStatus === 'InTransit' ||
     manifestStatus === 'ReadyForSignature';
 
+  const isDraft = manifestData?.manifestTrackingNumber === undefined;
+
   // Keep this here for development purposes
   // console.log(manifestData);
   // if (errors) console.log('errors', errors);
@@ -154,13 +159,10 @@ export function ManifestForm({
                   <HtForm.Group>
                     <HtForm.Label htmlFor="status" className="mb-0">
                       {'Status '}
-                      {readOnly ||
-                      (manifestStatus !== 'NotAssigned' && manifestStatus !== 'Pending') ? (
+                      {!isDraft && (
                         <InfoIconTooltip
                           message={'Once set to scheduled, this field is managed by EPA'}
                         />
-                      ) : (
-                        <></>
                       )}
                     </HtForm.Label>
                     <HtForm.Select


### PR DESCRIPTION
## Description

This PR fixes the bug where the status field becomes disabled after a draft manifest is set to scheduled.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #478 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
