### PR TITLE
Browsable api auth

### DIFF
--- a/server/apps/core/views/profile_views.py
+++ b/server/apps/core/views/profile_views.py
@@ -1,6 +1,6 @@
 from celery.exceptions import CeleryError
 from django.contrib.auth.models import User
-from rest_framework import permissions, status
+from rest_framework import status
 from rest_framework.generics import GenericAPIView, RetrieveAPIView, RetrieveUpdateAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,7 +18,6 @@ class HaztrakUserView(RetrieveUpdateAPIView):
 
     queryset = HaztrakUser.objects.all()
     serializer_class = HaztrakUserSerializer
-    permission_classes = [permissions.AllowAny]  # ToDo - temporary remove this
 
     def get_object(self):
         # return HaztrakUser.objects.get(username="testuser1")

--- a/server/apps/core/views/task_views.py
+++ b/server/apps/core/views/task_views.py
@@ -1,6 +1,6 @@
 from celery.result import AsyncResult
 from django_celery_results.models import TaskResult
-from rest_framework import permissions, serializers, status
+from rest_framework import serializers, status
 from rest_framework.generics import GenericAPIView, RetrieveAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -29,8 +29,6 @@ class ExampleTaskView(RetrieveAPIView):
     Launches an example long-running background task
     """
 
-    permission_classes = [permissions.AllowAny]
-
     def retrieve(self, request, *args, **kwargs):
         try:
             task = example_task.delay()
@@ -49,7 +47,6 @@ class TaskStatusView(GenericAPIView):
 
     serializer_class = CeleryTaskResultSerializer
     queryset = None
-    permission_classes = [permissions.AllowAny]
 
     def get(self, request: Request, task_id):
         task_result = AsyncResult(task_id)

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -3,7 +3,7 @@ import logging
 from celery.exceptions import TaskError
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema
-from rest_framework import permissions, status, viewsets
+from rest_framework import status, viewsets
 from rest_framework.generics import GenericAPIView, ListAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -28,7 +28,6 @@ class ManifestView(viewsets.ModelViewSet):
     queryset = Manifest.objects.all()
     lookup_field = "mtn"
     serializer_class = ManifestSerializer
-    permission_classes = [permissions.AllowAny]  # uncomment for debugging via (browsable API)
 
 
 class PullManifestView(GenericAPIView):

--- a/server/haztrak/settings.py
+++ b/server/haztrak/settings.py
@@ -147,6 +147,7 @@ STATICFILES_DIRS = [
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     # 'DEFAULT_PERMISSION_CLASSES': [],  # uncomment to use browser to inspect the API for dev

--- a/server/haztrak/urls.py
+++ b/server/haztrak/urls.py
@@ -22,6 +22,7 @@ admin.site.site_header = "Haztrak Admin"
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api-auth", include("rest_framework.urls")),
     path(
         "api/",
         include(


### PR DESCRIPTION
## Description

This is a quick chore/fix that allows haztrak developers to use the browsable API as described in the DRF docs here https://www.django-rest-framework.org/tutorial/4-authentication-and-permissions/#adding-login-to-the-browsable-api.

It's embarrassing I haven't had this setup a long time LOL. Very convenient. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
