### PR TITLE
Create e manifest

### DIFF
--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -86,7 +86,10 @@ export function ManifestForm({
   // Function to handle form submission
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
     console.log('Manifest Submitted', data);
-    htApi.post('/rcra/manifest/create', data).catch((r) => console.error(r));
+    htApi
+      .post('/rcra/manifest/create', data)
+      .then((response) => console.log(response))
+      .catch((r) => console.error(r));
   };
 
   // Generator state and methods

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -8,6 +8,7 @@ import React, { createContext, useEffect, useState } from 'react';
 import { Alert, Button, Col, Form, Row } from 'react-bootstrap';
 import { FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { htApi } from 'services';
 import { ContactForm, PhoneForm } from './Contact';
 import { AddHandler, GeneratorForm, Handler } from './Handler';
 import { Manifest, manifestSchema, ManifestStatus } from './manifestSchema';
@@ -85,6 +86,7 @@ export function ManifestForm({
   // Function to handle form submission
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
     console.log('Manifest Submitted', data);
+    htApi.post('/rcra/manifest/create', data).catch((r) => console.error(r));
   };
 
   // Generator state and methods

--- a/client/src/features/manifest/NewManifest.tsx
+++ b/client/src/features/manifest/NewManifest.tsx
@@ -11,6 +11,13 @@ import { useParams } from 'react-router-dom';
 import { useAppSelector } from 'store';
 import { siteByEpaIdSelector } from 'store/rcraProfileSlice/rcraProfile.slice';
 
+/**
+ * NewManifest component allows a user to create a new electronic manifest.
+ * It requires that the site the user is drafting the manifest for is specified,
+ * if haztrak cannot determine the site, the user will be prompted to select the site before
+ * presenting the manifest form.
+ * @constructor
+ */
 export function NewManifest() {
   useTitle('New Manifest');
   const { siteId } = useParams();

--- a/server/apps/sites/serializers/contact_ser.py
+++ b/server/apps/sites/serializers/contact_ser.py
@@ -13,6 +13,7 @@ class RcraPhoneSerializer(SitesBaseSerializer):
     number = serializers.CharField()
     extension = serializers.CharField(
         required=False,
+        allow_blank=True,
     )
 
     class Meta:

--- a/server/apps/trak/serializers/manifest_ser.py
+++ b/server/apps/trak/serializers/manifest_ser.py
@@ -23,26 +23,28 @@ logger = logging.getLogger(__name__)
 
 class AdditionalInfoSerializer(serializers.ModelSerializer):
     originalManifestTrackingNumbers = serializers.JSONField(
-        allow_null=True,
+        allow_null=False,
         required=False,
         source="original_mtn",
     )
     newManifestDestination = serializers.CharField(
-        allow_null=True,
+        allow_null=False,
         required=False,
+        allow_blank=True,
         source="new_destination",
     )
     consentNumber = serializers.CharField(
-        allow_null=True,
+        allow_null=False,
         required=False,
+        allow_blank=True,
         source="consent_number",
     )
     comments = serializers.JSONField(
-        allow_null=True,
+        allow_null=False,
         required=False,
     )
     handlingInstructions = serializers.CharField(
-        allow_null=True,
+        allow_null=False,
         allow_blank=True,
         required=False,
         source="handling_instructions",

--- a/server/apps/trak/serializers/manifest_ser.py
+++ b/server/apps/trak/serializers/manifest_ser.py
@@ -5,7 +5,12 @@ from rest_framework import serializers
 
 from apps.sites.models import RcraStates, Role
 from apps.trak.models import Manifest
-from apps.trak.models.manifest_models import AdditionalInfo, ImportInfo, PortOfEntry, CorrectionInfo
+from apps.trak.models.manifest_models import (
+    AdditionalInfo,
+    CorrectionInfo,
+    ImportInfo,
+    PortOfEntry,
+)
 from apps.trak.serializers.handler_ser import HandlerSerializer
 from apps.trak.serializers.signature_ser import ESignatureSerializer
 
@@ -100,6 +105,7 @@ class ManifestSerializer(TrakBaseSerializer):
     manifestTrackingNumber = serializers.CharField(
         source="mtn",
         required=False,
+        allow_blank=True,
     )
     # status
     submissionType = serializers.CharField(
@@ -320,7 +326,7 @@ class CorrectionInfoSerializer(TrakBaseSerializer):
     """
     Serializer for Correction Info
     """
-    
+
     versionNumber = serializers.CharField(
         source="version_number",
         required=False,
@@ -343,18 +349,18 @@ class CorrectionInfoSerializer(TrakBaseSerializer):
         allow_null=True,
     )
     epaSiteId = serializers.CharField(
-        source = "epa_site_id",
+        source="epa_site_id",
         required=False,
         allow_null=True,
     )
     initiatorRole = serializers.ChoiceField(
-        source = "initiator_role",
+        source="initiator_role",
         choices=Role.choices,
         required=False,
         allow_null=True,
     )
     updateRole = serializers.ChoiceField(
-        source = "update_role",
+        source="update_role",
         choices=Role.choices,
         required=False,
         allow_null=True,
@@ -370,4 +376,4 @@ class CorrectionInfoSerializer(TrakBaseSerializer):
             "epaSiteId",
             "initiatorRole",
             "updateRole",
-            ]
+        ]

--- a/server/apps/trak/services/manifest_service.py
+++ b/server/apps/trak/services/manifest_service.py
@@ -150,6 +150,16 @@ class ManifestService:
             results["error"].extend(results["success"])  # Temporary
         return results
 
+    def create_rcra_manifest(self, *, manifest: Dict):
+        """
+        Create a manifest in RCRAInfo through the RESTful API.
+        :param manifest: Dict
+        :return:
+        """
+        # print("manifest service manifest: ", manifest)
+        resp = self.rcrainfo.save_manifest(manifest)
+        print("resp: ", resp.json())
+
     def _filter_mtn(self, signature: QuickerSign) -> dict[str, list[str]]:
         results = {"success": [], "error": []}
         site_filter = Manifest.objects.get_handler_query(signature.site_id, signature.site_type)

--- a/server/apps/trak/tasks/__init__.py
+++ b/server/apps/trak/tasks/__init__.py
@@ -1,2 +1,2 @@
 from .lookup_task import pull_federal_codes
-from .manifest_task import pull_manifest, sign_manifest, sync_site_manifests
+from .manifest_task import create_rcra_manifest, pull_manifest, sign_manifest, sync_site_manifests

--- a/server/apps/trak/tasks/manifest_task.py
+++ b/server/apps/trak/tasks/manifest_task.py
@@ -89,11 +89,18 @@ def sync_site_manifests(self, *, site_id: str, username: str):
 # create_rcra_manifest
 @shared_task(name="create rcra manifests", bind=True)
 def create_rcra_manifest(self, *, manifest: dict, username: str):
+    """
+    asynchronous task to use the RCRAInfo web services to create an electronic (RCRA) manifest
+    it accepts a Python dict of the manifest data to be submitted as JSON, and the username of the
+    user who is creating the manifest
+    """
     from apps.trak.services import ManifestService
 
-    logger.info(f"start task: {self.name}; manifest: ToDo")
+    logger.info(f"start task: {self.name}")
     try:
-        manifest_service = ManifestService(username=username)
-        manifest_service.create_rcra_manifest(manifest=manifest)
+        logger.debug(f"creating manifest: {manifest}")
+        ManifestService(username=username)
+        print(manifest["additionalInfo"])
+        # manifest_service.create_rcra_manifest(manifest=manifest)
     except Exception as exc:
-        print("error: ", exc)
+        logger.error("error: ", exc)

--- a/server/apps/trak/tasks/manifest_task.py
+++ b/server/apps/trak/tasks/manifest_task.py
@@ -88,5 +88,12 @@ def sync_site_manifests(self, *, site_id: str, username: str):
 
 # create_rcra_manifest
 @shared_task(name="create rcra manifests", bind=True)
-def create_rcra_manifest(self, *, manifest: dict):
-    print("manifest data from task: ", manifest)
+def create_rcra_manifest(self, *, manifest: dict, username: str):
+    from apps.trak.services import ManifestService
+
+    logger.info(f"start task: {self.name}; manifest: ToDo")
+    try:
+        manifest_service = ManifestService(username=username)
+        manifest_service.create_rcra_manifest(manifest=manifest)
+    except Exception as exc:
+        print("error: ", exc)

--- a/server/apps/trak/tasks/manifest_task.py
+++ b/server/apps/trak/tasks/manifest_task.py
@@ -99,8 +99,7 @@ def create_rcra_manifest(self, *, manifest: dict, username: str):
     logger.info(f"start task: {self.name}")
     try:
         logger.debug(f"creating manifest: {manifest}")
-        ManifestService(username=username)
-        print(manifest["additionalInfo"])
-        # manifest_service.create_rcra_manifest(manifest=manifest)
+        manifest_service = ManifestService(username=username)
+        manifest_service.create_rcra_manifest(manifest=manifest)
     except Exception as exc:
         logger.error("error: ", exc)

--- a/server/apps/trak/tasks/manifest_task.py
+++ b/server/apps/trak/tasks/manifest_task.py
@@ -84,3 +84,9 @@ def sync_site_manifests(self, *, site_id: str, username: str):
         logger.error(f"failed to sync {site_id} manifest")
         self.update_state(state=states.FAILURE, meta=f"Internal Error {exc}")
         raise Ignore()
+
+
+# create_rcra_manifest
+@shared_task(name="create rcra manifests", bind=True)
+def create_rcra_manifest(self, *, manifest: dict):
+    print("manifest data from task: ", manifest)

--- a/server/apps/trak/urls.py
+++ b/server/apps/trak/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path
 from rest_framework import routers
 
 from apps.trak.views import (
+    CreateRcraManifestView,
     FederalWasteCodesView,
     ManifestView,
     MtnList,
@@ -17,6 +18,7 @@ manifest_router.register(r"manifest", ManifestView)
 urlpatterns = [
     # Manifest
     path("", include(manifest_router.urls)),
+    path("manifest/create", CreateRcraManifestView.as_view()),
     path("manifest/pull", PullManifestView.as_view()),
     path("manifest/sign", SignManifestView.as_view()),
     path("manifest/sync", SyncSiteManifestView.as_view()),

--- a/server/apps/trak/urls.py
+++ b/server/apps/trak/urls.py
@@ -18,7 +18,7 @@ manifest_router.register(r"manifest", ManifestView)
 urlpatterns = [
     # Manifest
     path("", include(manifest_router.urls)),
-    path("manifest/create", CreateRcraManifestView.as_view()),
+    path("rcra/manifest/create", CreateRcraManifestView.as_view()),
     path("manifest/pull", PullManifestView.as_view()),
     path("manifest/sign", SignManifestView.as_view()),
     path("manifest/sync", SyncSiteManifestView.as_view()),

--- a/server/apps/trak/views/__init__.py
+++ b/server/apps/trak/views/__init__.py
@@ -1,5 +1,6 @@
 from .lookup_views import FederalWasteCodesView, StateWasteCodesView
 from .manifest_view import (
+    CreateRcraManifestView,
     ManifestView,
     MtnList,
     PullManifestView,

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -120,3 +120,19 @@ class SyncSiteManifestView(GenericAPIView):
             return self.response(
                 data={"error": "malformed payload"}, status=status.HTTP_400_BAD_REQUEST
             )
+
+
+class CreateRcraManifestView(GenericAPIView):
+    """
+    This is a proxy endpoint used to create electronic manifest(s) in RCRAInfo/e-Manifest
+    """
+
+    queryset = None
+    response = Response
+
+    def post(self, request: Request) -> Response:
+        """The Body of the POST request should contain the complete and valid manifest object"""
+        # ToDo: Validate the manifest object
+        print("request.data: ", request.data)
+        # task = save_manifest.delay(manifest_json=request.data)
+        return self.response(data={"task": "scaffold"}, status=status.HTTP_201_CREATED)

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -135,7 +135,6 @@ class CreateRcraManifestView(GenericAPIView):
 
     def post(self, request: Request) -> Response:
         """The Body of the POST request should contain the complete and valid manifest object"""
-        # ToDo: Validate the manifest object
         manifest_serializer = self.serializer_class(data=request.data)
         if manifest_serializer.is_valid():
             logger.info(

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -12,7 +12,7 @@ from apps.sites.models import Site
 from apps.trak.models import Manifest
 from apps.trak.serializers import ManifestSerializer, MtnSerializer
 from apps.trak.serializers.signature_ser import QuickerSignSerializer
-from apps.trak.tasks import pull_manifest, sign_manifest, sync_site_manifests
+from apps.trak.tasks import create_rcra_manifest, pull_manifest, sign_manifest, sync_site_manifests
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +135,5 @@ class CreateRcraManifestView(GenericAPIView):
     def post(self, request: Request) -> Response:
         """The Body of the POST request should contain the complete and valid manifest object"""
         # ToDo: Validate the manifest object
-        print("request.data: ", request.data)
-        # task = save_manifest.delay(manifest_json=request.data)
-        return self.response(data={"task": "scaffold"}, status=status.HTTP_201_CREATED)
+        task = create_rcra_manifest.delay(manifest=request.data)
+        return self.response(data={"task": task.id}, status=status.HTTP_201_CREATED)

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -129,6 +129,8 @@ class CreateRcraManifestView(GenericAPIView):
 
     queryset = None
     response = Response
+    serializer_class = ManifestSerializer
+    http_method_names = ["post"]
 
     def post(self, request: Request) -> Response:
         """The Body of the POST request should contain the complete and valid manifest object"""

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -135,5 +135,5 @@ class CreateRcraManifestView(GenericAPIView):
     def post(self, request: Request) -> Response:
         """The Body of the POST request should contain the complete and valid manifest object"""
         # ToDo: Validate the manifest object
-        task = create_rcra_manifest.delay(manifest=request.data)
+        task = create_rcra_manifest.delay(manifest=request.data, username=str(request.user))
         return self.response(data={"task": task.id}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Description

This PR adds a service (for our frontend) for creating electronic manifest through the RCRAInfo manifest save service.

what that includes
1. URL routing
2. CreateRcraManifestView
3. a create_rcra_manifest celery task to offload the process from the HTTP lifecycle (between our front end and backend)
4. a create_rcra_manifest use case ("service") that actually uses the RCRAInfo service

Through this process, we've already created one electronic manifest, although we now we can see some of the errors that RCRAInfo is throwing back at Haztrak. Future front end validation is needed (like for example, if DOT hazardous is true then we need to modify the field name of the "Waste Description" form text box to "dotInformation". There also some work with the "additionalInfo" data that may need polishing. But hey, we're close.   


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #558 
closes #559 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
