### PR TITLE
Rest api design

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,7 +27,7 @@
         "react-router-dom": "^6.16.0",
         "react-select": "^5.7.7",
         "sass": "^1.68.0",
-        "zod": "^3.22.2"
+        "zod": "^3.22.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.3",
@@ -11362,9 +11362,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "react-router-dom": "^6.16.0",
     "react-select": "^5.7.7",
     "sass": "^1.68.0",
-    "zod": "^3.22.2"
+    "zod": "^3.22.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.3",

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -96,7 +96,7 @@ export function ManifestForm({
   const onSubmit: SubmitHandler<Manifest> = (data: Manifest) => {
     console.log('Manifest Submitted', data);
     htApi
-      .post<TaskStatus>('/rcra/manifest/create', data)
+      .post<TaskStatus>('/rcra/manifest', data)
       .then((response) => {
         return response;
       })

--- a/client/src/components/Manifest/QuickerSign/QuickerSignForm.tsx
+++ b/client/src/components/Manifest/QuickerSign/QuickerSignForm.tsx
@@ -59,7 +59,7 @@ export function QuickerSignForm({ mtn, mtnHandler, handleClose, siteType }: Quic
       };
     }
     htApi
-      .post('/manifest/sign', signature)
+      .post('rcra/manifest/sign', signature)
       .then((response: AxiosResponse) => {
         dispatch(
           addNotification({

--- a/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.spec.tsx
+++ b/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.spec.tsx
@@ -11,7 +11,7 @@ const testTaskID = 'testTaskId';
 
 const server = setupServer(
   ...[
-    rest.post(`${API_BASE_URL}/manifest/sync`, (req, res, ctx) => {
+    rest.post(`${API_BASE_URL}rcra/manifest/sync`, (req, res, ctx) => {
       // Mock Sync Site Manifests response
       return res(
         ctx.status(200),

--- a/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
+++ b/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
@@ -1,8 +1,8 @@
 import { faSync } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { RcraApiUserBtn } from 'components/buttons';
 import React, { useState } from 'react';
 import { htApi } from 'services';
-import { RcraApiUserBtn } from 'components/buttons';
 import { addNotification, useAppDispatch } from 'store';
 
 interface SyncManifestProps {
@@ -18,8 +18,7 @@ interface SyncManifestProps {
 export function SyncManifestBtn({ siteId, disabled }: SyncManifestProps) {
   const [syncingMtn, setSyncingMtn] = useState(false);
   const dispatch = useAppDispatch();
-  let active: boolean = siteId ? true : false;
-  active = !disabled;
+  const active = !disabled;
 
   return (
     <RcraApiUserBtn
@@ -29,7 +28,7 @@ export function SyncManifestBtn({ siteId, disabled }: SyncManifestProps) {
       onClick={() => {
         setSyncingMtn(!syncingMtn);
         htApi
-          .post('/manifest/sync', { siteId: `${siteId}` })
+          .post('rcra/manifest/sync', { siteId: `${siteId}` })
           .then((response) => {
             dispatch(
               addNotification({

--- a/client/src/features/home/Home.spec.tsx
+++ b/client/src/features/home/Home.spec.tsx
@@ -1,16 +1,16 @@
 import '@testing-library/jest-dom';
-import { Home } from './Home';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { API_BASE_URL, handlers } from 'test-utils/mock/handlers';
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
+import { Home } from './Home';
 
 const USERNAME = 'testuser1';
 
 const myAPIHandlers = [
-  rest.get(`${API_BASE_URL}/api/user/${USERNAME}/rcra/profile`, (req, res, ctx) => {
+  rest.get(`${API_BASE_URL}/api/rcra/profile/${USERNAME}`, (req, res, ctx) => {
     return res(
       // Respond with a 200 status code
       ctx.status(200),

--- a/client/src/features/manifestDetails/ManifestDetails.tsx
+++ b/client/src/features/manifestDetails/ManifestDetails.tsx
@@ -8,7 +8,7 @@ import { useParams } from 'react-router-dom';
 export function ManifestDetails() {
   const { mtn, action, siteId } = useParams();
   useTitle(`${mtn}`);
-  const [manifestData, loading, error] = useHtApi<Manifest>(`manifest/${mtn}`);
+  const [manifestData, loading, error] = useHtApi<Manifest>(`rcra/manifest/${mtn}`);
 
   let readOnly = true;
   if (action === 'edit') {

--- a/client/src/features/manifestList/ManifestList.tsx
+++ b/client/src/features/manifestList/ManifestList.tsx
@@ -16,9 +16,9 @@ export function ManifestList(): ReactElement {
   useTitle(`${siteId || ''} Manifest`);
   const [pageSize, setPageSize] = useState(10);
 
-  let getUrl = 'mtn';
+  let getUrl = 'rcra/mtn';
   if (siteId) {
-    getUrl = `mtn/${siteId}`;
+    getUrl = `rcra/mtn/${siteId}`;
   }
 
   const [mtnList, loading, error] = useHtApi<Array<MtnDetails>>(getUrl);

--- a/client/src/features/notifications/Notifications.tsx
+++ b/client/src/features/notifications/Notifications.tsx
@@ -1,5 +1,4 @@
-import { faFaceSmile } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import winkingRobot from '/static/robot-wink.jpg';
 import { HtCard } from 'components/Ht';
 import { NotificationRow } from 'components/Notification';
 import { useTitle } from 'hooks';
@@ -25,8 +24,8 @@ export function Notifications() {
             <HtCard.Body>
               {notifications.length === 0 ? (
                 <div className="text-center">
-                  <h3>Nothing to see here, you're all caught up!</h3>
-                  <FontAwesomeIcon className="text-info" icon={faFaceSmile} size={'6x'} />
+                  <h3>You're all caught up!</h3>
+                  <img src={winkingRobot} alt="happy robot" width={200} height={'auto'} />
                 </div>
               ) : (
                 <Table hover>

--- a/client/src/features/profile/RcraProfile.tsx
+++ b/client/src/features/profile/RcraProfile.tsx
@@ -4,11 +4,11 @@ import { HtForm } from 'components/Ht';
 import React, { useState } from 'react';
 import { Button, Col, Container, Form, Row, Table } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
+import { Link } from 'react-router-dom';
+import { htApi } from 'services';
 import { addNotification, useAppDispatch } from 'store';
 import { getProfile, updateProfile } from 'store/rcraProfileSlice';
 import { RcraProfileState } from 'store/rcraProfileSlice/rcraProfile.slice';
-import { htApi } from 'services';
-import { Link } from 'react-router-dom';
 import { z } from 'zod';
 
 interface ProfileViewProps {
@@ -48,7 +48,7 @@ export function RcraProfile({ profile }: ProfileViewProps) {
     setProfileLoading(!profileLoading);
     setEditable(!editable);
     htApi
-      .put(`/user/${profile.user}/rcra/profile`, data)
+      .put(`/rcra/profile/${profile.user}`, data)
       .then((r) => {
         dispatch(updateProfile(r.data));
       })

--- a/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
+++ b/client/src/store/rcraProfileSlice/rcraProfile.slice.ts
@@ -96,7 +96,7 @@ export const getProfile = createAsyncThunk<RcraProfileState>(
   async (arg, thunkAPI) => {
     const state = thunkAPI.getState() as RootState;
     const username = state.user.user?.username;
-    const response = await htApi.get(`/user/${username}/rcra/profile`);
+    const response = await htApi.get(`/rcra/profile/${username}`);
     const { rcraSites, ...rest } = response.data as RcraProfileResponse;
     // Convert the array of RcraSite permissions we get from our backend
     // to an object which each key corresponding to the RcraSite's ID number

--- a/client/src/store/site.slice.ts
+++ b/client/src/store/site.slice.ts
@@ -14,24 +14,22 @@ interface RcrainfoSiteSearch {
 export const siteApi = createApi({
   reducerPath: 'siteApi',
   baseQuery: htApiBaseQuery({
-    baseUrl: `${import.meta.env.VITE_HT_API_URL}/api/site`,
+    baseUrl: `${import.meta.env.VITE_HT_API_URL}/api/`,
   }),
   endpoints: (build) => ({
     searchRcrainfoSites: build.query<Array<RcraSite>, RcrainfoSiteSearch>({
       query: (data: RcrainfoSiteSearch) => ({
-        url: '/rcrainfo/search',
+        url: 'rcra/handler/search',
         method: 'post',
         data: data,
       }),
     }),
     searchRcraSites: build.query<Array<RcraSite>, RcrainfoSiteSearch>({
       query: (data: RcrainfoSiteSearch) => ({
-        url: '/search',
+        url: 'site/search',
         method: 'get',
         params: { epaId: data.siteId, siteType: data.siteType },
       }),
     }),
   }),
 });
-
-export const { useSearchRcraSitesQuery, useSearchRcrainfoSitesQuery } = siteApi;

--- a/client/src/store/wasteCode.slice.ts
+++ b/client/src/store/wasteCode.slice.ts
@@ -9,7 +9,7 @@ import { htApiBaseQuery } from 'store/baseQuery';
 export const wasteCodeApi = createApi({
   reducerPath: 'wasteCodeApi',
   baseQuery: htApiBaseQuery({
-    baseUrl: `${import.meta.env.VITE_HT_API_URL}/api/code/`,
+    baseUrl: `${import.meta.env.VITE_HT_API_URL}/api/rcra/code/`,
   }),
   endpoints: (build) => ({
     getFedWasteCodes: build.query<Array<Code>, void>({

--- a/client/src/test-utils/mock/handlers.ts
+++ b/client/src/test-utils/mock/handlers.ts
@@ -57,13 +57,13 @@ export const handlers = [
   /**
    * mock Manifest
    */
-  rest.get(`${API_BASE_URL}/api/manifest/${mockMTN}`, (req, res, ctx) => {
+  rest.get(`${API_BASE_URL}/api/rcra/manifest/${mockMTN}`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(createMockManifest()));
   }),
   /**
    * list of manifests ('My Manifests' feature and a site's manifests)
    */
-  rest.get(`${API_BASE_URL}/api/mtn*`, (req, res, ctx) => {
+  rest.get(`${API_BASE_URL}/api/rcra/mtn*`, (req, res, ctx) => {
     const mockManifestArray = [
       createMockManifest(),
       createMockManifest({ manifestTrackingNumber: '987654321ELC', status: 'Pending' }),

--- a/client/src/test-utils/mock/handlers.ts
+++ b/client/src/test-utils/mock/handlers.ts
@@ -28,7 +28,7 @@ export const handlers = [
   /**
    * User RcraProfile data
    */
-  rest.get(`${API_BASE_URL}/api/user/${mockUsername}/rcra/profile`, (req, res, ctx) => {
+  rest.get(`${API_BASE_URL}/api/rcra/profile/${mockUsername}`, (req, res, ctx) => {
     return res(
       // Respond with a 200 status code
       ctx.status(200),

--- a/server/apps/core/urls.py
+++ b/server/apps/core/urls.py
@@ -1,6 +1,6 @@
-from django.urls import path
+from django.urls import include, path
 
-from .views import (
+from .views import (  # type: ignore
     HaztrakUserView,
     LaunchExampleTaskView,
     Login,
@@ -11,8 +11,15 @@ from .views import (
 
 urlpatterns = [
     # Rcra Profile
-    path("user/<str:username>/rcra/profile/sync", RcraProfileSyncView.as_view()),
-    path("user/<str:username>/rcra/profile", RcraProfileView.as_view()),
+    path(
+        "rcra/",
+        include(
+            [
+                path("profile/<str:username>/sync", RcraProfileSyncView.as_view()),
+                path("profile/<str:username>", RcraProfileView.as_view()),
+            ]
+        ),
+    ),
     path("user", HaztrakUserView.as_view()),
     path("user/login", Login.as_view()),
     path("task/example", LaunchExampleTaskView.as_view()),

--- a/server/apps/sites/tests/test_epa_profile_views.py
+++ b/server/apps/sites/tests/test_epa_profile_views.py
@@ -1,9 +1,8 @@
 import pytest
 from rest_framework import status
-from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from apps.core.views import RcraProfileView
+from apps.core.views import RcraProfileView  # type: ignore
 
 
 class TestRcraProfileView:
@@ -11,7 +10,7 @@ class TestRcraProfileView:
     Tests the for the endpoints related to the user's RcraProfile
     """
 
-    URL = "/api/user"
+    URL = "/api/"
     id_field = "rcraAPIID"
     key_field = "rcraAPIKey"
     username_field = "rcraUsername"
@@ -28,7 +27,7 @@ class TestRcraProfileView:
     def rcra_profile_request(self, user_and_client):
         factory = APIRequestFactory()
         request = factory.put(
-            f"{self.URL}/{self.user.username}/rcra/profile",
+            f"{self.URL}rcra/profile{self.user.username}",
             {
                 self.id_field: self.new_api_id,
                 self.username_field: self.new_username,
@@ -43,7 +42,7 @@ class TestRcraProfileView:
         # Arrange
         rcra_profile_factory(user=self.user)
         # Act
-        response: Response = self.client.get(f"{self.URL}/{self.user.username}/rcra/profile")
+        response = self.client.get(f"{self.URL}rcra/profile/{self.user.username}")
         # Assert
         assert response.headers["Content-Type"] == "application/json"
         assert response.status_code == status.HTTP_200_OK

--- a/server/apps/sites/tests/test_epa_site_views.py
+++ b/server/apps/sites/tests/test_epa_site_views.py
@@ -3,8 +3,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
-from apps.sites.models import RcraSiteType
-from apps.sites.views import SiteSearchView
+from apps.sites.models import RcraSiteType  # type: ignore
+from apps.sites.views import SiteSearchView  # type: ignore
 
 
 class TestEpaSiteView:
@@ -12,7 +12,7 @@ class TestEpaSiteView:
     Tests the for the endpoints related to the handlers
     """
 
-    URL = "/api/site/rcra-site"
+    URL = "/api/rcra/handler"
 
     @pytest.fixture
     def client(self, rcra_site_factory, api_client_factory):

--- a/server/apps/sites/tests/test_site_views.py
+++ b/server/apps/sites/tests/test_site_views.py
@@ -3,12 +3,11 @@ from typing import Optional
 import pytest
 from django.contrib.auth.models import User
 from rest_framework import status
-from rest_framework.response import Response
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
-from apps.core.models import RcraProfile
-from apps.sites.models import RcraSite, RcraSitePermission, Site
-from apps.sites.views import SiteDetailView, SiteMtnListView
+from apps.core.models import RcraProfile  # type: ignore
+from apps.sites.models import RcraSite, RcraSitePermission, Site  # type: ignore
+from apps.sites.views import SiteDetailView  # type: ignore
 
 
 class TestSiteListView:
@@ -96,7 +95,7 @@ class TestSiteDetailsApi:
 
         return create_site_and_related
 
-    def test_returns_site_by_id(self, user_factory, local_site_factory):
+    def test_returns_site_by_id(self, user_factory, local_site_factory) -> None:
         # Arrange
         user = user_factory(username="username1")
         site = local_site_factory(user=user)
@@ -132,28 +131,3 @@ class TestSiteDetailsApi:
         # Assert
         assert response.headers["Content-Type"] == "application/json"
         assert response.status_code == status.HTTP_200_OK
-
-
-class TestSiteManifest:
-    """
-    Tests for the endpoint to retrieve a Site's manifests
-    """
-
-    # ToDo fix these false positive tests
-
-    url = "/api/site"
-
-    @pytest.fixture(autouse=True)
-    def _user(self, user_factory):
-        self.user = user_factory()
-
-    @pytest.fixture(autouse=True)
-    def _generator(self, rcra_site_factory):
-        self.generator = rcra_site_factory()
-
-    def test_returns_200(self):
-        factory = APIRequestFactory()
-        request = factory.get(f"{self.url}/{self.generator.epa_id}/manifest")
-        force_authenticate(request, self.user)
-        response: Response = SiteMtnListView.as_view()(request, self.generator.epa_id)
-        print(response.data)

--- a/server/apps/sites/urls.py
+++ b/server/apps/sites/urls.py
@@ -1,6 +1,6 @@
-from django.urls import path
+from django.urls import include, path
 
-from apps.sites.views import (
+from apps.sites.views import (  # type: ignore
     RcraSiteView,
     SiteDetailView,
     SiteListView,
@@ -10,11 +10,18 @@ from apps.sites.views import (
 )
 
 urlpatterns = [
+    path(
+        "rcra/",
+        include(
+            [
+                path("handler/search", rcrainfo_site_search_view),
+                path("handler/<int:pk>", RcraSiteView.as_view()),
+            ]
+        ),
+    ),
     # Site
     path("site", SiteListView.as_view()),
     path("site/search", SiteSearchView.as_view()),
     path("site/<str:epa_id>", SiteDetailView.as_view()),
     path("site/<str:epa_id>/manifest", SiteMtnListView.as_view()),
-    path("site/rcra-site/<int:pk>", RcraSiteView.as_view()),
-    path("site/rcrainfo/search", rcrainfo_site_search_view),
 ]

--- a/server/apps/sites/urls.py
+++ b/server/apps/sites/urls.py
@@ -4,7 +4,6 @@ from apps.sites.views import (  # type: ignore
     RcraSiteView,
     SiteDetailView,
     SiteListView,
-    SiteMtnListView,
     SiteSearchView,
     rcrainfo_site_search_view,
 )
@@ -23,5 +22,4 @@ urlpatterns = [
     path("site", SiteListView.as_view()),
     path("site/search", SiteSearchView.as_view()),
     path("site/<str:epa_id>", SiteDetailView.as_view()),
-    path("site/<str:epa_id>/manifest", SiteMtnListView.as_view()),
 ]

--- a/server/apps/sites/urls.py
+++ b/server/apps/sites/urls.py
@@ -1,11 +1,11 @@
 from django.urls import include, path
 
 from apps.sites.views import (  # type: ignore
+    HandlerSearchView,
     RcraSiteView,
     SiteDetailView,
     SiteListView,
     SiteSearchView,
-    rcrainfo_site_search_view,
 )
 
 urlpatterns = [
@@ -13,7 +13,7 @@ urlpatterns = [
         "rcra/",
         include(
             [
-                path("handler/search", rcrainfo_site_search_view),
+                path("handler/search", HandlerSearchView.as_view()),
                 path("handler/<int:pk>", RcraSiteView.as_view()),
             ]
         ),

--- a/server/apps/sites/views/__init__.py
+++ b/server/apps/sites/views/__init__.py
@@ -1,8 +1,7 @@
-from .site_views import (
+from .site_views import (  # type: ignore
     RcraSiteView,
     SiteDetailView,
     SiteListView,
-    SiteMtnListView,
     SiteSearchView,
     rcrainfo_site_search_view,
 )

--- a/server/apps/sites/views/__init__.py
+++ b/server/apps/sites/views/__init__.py
@@ -1,7 +1,7 @@
 from .site_views import (  # type: ignore
+    HandlerSearchView,
     RcraSiteView,
     SiteDetailView,
     SiteListView,
     SiteSearchView,
-    rcrainfo_site_search_view,
 )

--- a/server/apps/trak/tests/views/test_manifest_views.py
+++ b/server/apps/trak/tests/views/test_manifest_views.py
@@ -10,7 +10,7 @@ from apps.trak.views import ManifestView, SignManifestView
 class TestManifestCRUD:
     """Tests the for the Manifest ModelViewSet"""
 
-    base_url = "/api/manifest"
+    base_url = "/api/rcra/manifest"
 
     @pytest.fixture
     def factory(self):
@@ -33,21 +33,10 @@ class TestManifestCRUD:
         request = factory.get(f"{self.base_url}/{manifest.mtn}")
         force_authenticate(request, user)
         # Act
-        response: Response = ManifestView.as_view({"get": "retrieve"})(request, mtn=manifest.mtn)
+        response: Response = ManifestView.as_view()(request, mtn=manifest.mtn)
         # Assert
         assert response.status_code == status.HTTP_200_OK
         assert response.data["manifestTrackingNumber"] == manifest.mtn
-
-    def test_manifest_from_epa_create_when_posted(self, factory, manifest_json, user):
-        request = factory.post(f"{self.base_url}", manifest_json, format="json")
-        force_authenticate(request, user)
-
-        response: Response = ManifestView.as_view({"post": "create"})(request)
-
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.data["manifestTrackingNumber"] == manifest_json.get(
-            "manifestTrackingNumber"
-        )
 
 
 class TestSignManifestVIew:

--- a/server/apps/trak/tests/views/test_manifest_views.py
+++ b/server/apps/trak/tests/views/test_manifest_views.py
@@ -1,7 +1,6 @@
 import pytest
 from celery.result import AsyncResult
 from rest_framework import status
-from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.trak.views import ManifestView, SignManifestView
@@ -33,7 +32,7 @@ class TestManifestCRUD:
         request = factory.get(f"{self.base_url}/{manifest.mtn}")
         force_authenticate(request, user)
         # Act
-        response: Response = ManifestView.as_view()(request, mtn=manifest.mtn)
+        response = ManifestView.as_view()(request, mtn=manifest.mtn)
         # Assert
         assert response.status_code == status.HTTP_200_OK
         assert response.data["manifestTrackingNumber"] == manifest.mtn
@@ -68,5 +67,5 @@ class TestSignManifestVIew:
             format="json",
         )
         force_authenticate(request, self.user)
-        response: Response = SignManifestView.as_view()(request)
+        response = SignManifestView.as_view()(request)
         assert response.data["task"] == self.mock_task_id

--- a/server/apps/trak/urls.py
+++ b/server/apps/trak/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import include, path
 
 from apps.trak.views import (  # type: ignore
     CreateRcraManifestView,
@@ -12,16 +12,23 @@ from apps.trak.views import (  # type: ignore
 )
 
 urlpatterns = [
-    # Manifest
-    path("manifest/<str:mtn>", ManifestView.as_view()),
-    path("rcra/manifest/create", CreateRcraManifestView.as_view()),
-    path("manifest/pull", PullManifestView.as_view()),
-    path("manifest/sign", SignManifestView.as_view()),
-    path("manifest/sync", SyncSiteManifestView.as_view()),
-    # MTN
-    path("mtn", MtnList.as_view()),
-    path("mtn/<str:epa_id>", MtnList.as_view()),
-    # Codes
-    path("code/waste/federal", FederalWasteCodesView.as_view()),
-    path("code/waste/state/<str:state_id>", StateWasteCodesView.as_view()),
+    path(
+        "rcra/*",
+        include(
+            [
+                # Manifest
+                path("manifest/<str:mtn>", ManifestView.as_view()),
+                path("manifest/create", CreateRcraManifestView.as_view()),
+                path("manifest/pull", PullManifestView.as_view()),
+                path("manifest/sign", SignManifestView.as_view()),
+                path("manifest/sync", SyncSiteManifestView.as_view()),
+                # MTN
+                path("mtn", MtnList.as_view()),
+                path("mtn/<str:epa_id>", MtnList.as_view()),
+                # Codes
+                path("code/waste/federal", FederalWasteCodesView.as_view()),
+                path("code/waste/state/<str:state_id>", StateWasteCodesView.as_view()),
+            ]
+        ),
+    ),
 ]

--- a/server/apps/trak/urls.py
+++ b/server/apps/trak/urls.py
@@ -16,8 +16,8 @@ urlpatterns = [
         include(
             [
                 # Manifest
+                path("manifest", CreateRcraManifestView.as_view()),
                 path("manifest/<str:mtn>", ManifestView.as_view()),
-                path("manifest/create", CreateRcraManifestView.as_view()),
                 path("manifest/sign", SignManifestView.as_view()),
                 path("manifest/sync", SyncSiteManifestView.as_view()),
                 # MTN

--- a/server/apps/trak/urls.py
+++ b/server/apps/trak/urls.py
@@ -1,7 +1,6 @@
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import path
 
-from apps.trak.views import (
+from apps.trak.views import (  # type: ignore
     CreateRcraManifestView,
     FederalWasteCodesView,
     ManifestView,
@@ -12,12 +11,9 @@ from apps.trak.views import (
     SyncSiteManifestView,
 )
 
-manifest_router = routers.SimpleRouter(trailing_slash=False)
-manifest_router.register(r"manifest", ManifestView)
-
 urlpatterns = [
     # Manifest
-    path("", include(manifest_router.urls)),
+    path("manifest/<str:mtn>", ManifestView.as_view()),
     path("rcra/manifest/create", CreateRcraManifestView.as_view()),
     path("manifest/pull", PullManifestView.as_view()),
     path("manifest/sign", SignManifestView.as_view()),

--- a/server/apps/trak/urls.py
+++ b/server/apps/trak/urls.py
@@ -5,7 +5,6 @@ from apps.trak.views import (  # type: ignore
     FederalWasteCodesView,
     ManifestView,
     MtnList,
-    PullManifestView,
     SignManifestView,
     StateWasteCodesView,
     SyncSiteManifestView,
@@ -13,13 +12,12 @@ from apps.trak.views import (  # type: ignore
 
 urlpatterns = [
     path(
-        "rcra/*",
+        "rcra/",
         include(
             [
                 # Manifest
                 path("manifest/<str:mtn>", ManifestView.as_view()),
                 path("manifest/create", CreateRcraManifestView.as_view()),
-                path("manifest/pull", PullManifestView.as_view()),
                 path("manifest/sign", SignManifestView.as_view()),
                 path("manifest/sync", SyncSiteManifestView.as_view()),
                 # MTN

--- a/server/apps/trak/views/__init__.py
+++ b/server/apps/trak/views/__init__.py
@@ -1,9 +1,8 @@
-from .lookup_views import FederalWasteCodesView, StateWasteCodesView
-from .manifest_view import (
+from .lookup_views import FederalWasteCodesView, StateWasteCodesView  # type: ignore
+from .manifest_view import (  # type: ignore
     CreateRcraManifestView,
     ManifestView,
     MtnList,
-    PullManifestView,
     SignManifestView,
     SyncSiteManifestView,
 )

--- a/server/apps/trak/views/manifest_view.py
+++ b/server/apps/trak/views/manifest_view.py
@@ -37,25 +37,6 @@ class ManifestView(RetrieveAPIView):
     serializer_class = ManifestSerializer
 
 
-class PullManifestView(GenericAPIView):
-    """
-    This endpoint launches a task to pull a manifest (by MTN) from RCRAInfo.
-    On success, returns the task queue ID.
-    """
-
-    queryset = None
-
-    def post(self, request: Request) -> Response:
-        try:
-            mtn = request.data["mtn"]
-            task = pull_manifest.delay(mtn=mtn, username=str(request.user))
-            return Response(data={"task": task.id}, status=status.HTTP_200_OK)
-        except KeyError:
-            return Response(
-                data={"error": "malformed payload"}, status=status.HTTP_400_BAD_REQUEST
-            )
-
-
 class MtnList(ListAPIView):
     """
     MtnList returns select details on a user's manifest,

--- a/server/haztrak/settings.py
+++ b/server/haztrak/settings.py
@@ -165,6 +165,7 @@ SPECTACULAR_SETTINGS = {
     "management software can integrate with EPA's RCRAInfo",
     "VERSION": HAZTRAK_VERSION,
     "SERVE_INCLUDE_SCHEMA": False,
+    "SCHEMA_PATH_PREFIX": r"/api\/(?:rcra)?",
     "EXTERNAL_DOCS": {
         "description": "Haztrak Documentation",
         "url": "https://usepa.github.io/haztrak/",


### PR DESCRIPTION
## Description
Removes a (surprising amount) of unused handler functions (django calls them views) from our rest API design. we also add the 'rcra' accronym (for Resource Conservation and Recovery) into our RESTful API url pattern to roughly signify that a resource is 
1. related to RCRA and not another EPA AA-ship like the clean water or clean air acts (there could be a `site` or `epaId` resource in those acts, although I'm not sure). This clarifies and makes the app a little more extensible if that information was added at a later date. 
2. the resource (again roughly) should follow the schemas described in the USEAP/e-manifest documentation.  

We also update the auto generated OpenAPI page to better reflect the organization of resources, and add useful details about the requests/responses of our API endpoints. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
