### PR TITLE
add platform args to build_image workflow

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: 'Build and push'
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           context: ${{ inputs.context }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description
adds arguments for building our images for architectures `linux/amd64` and `linux/arm64`

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
