### PR TITLE
add docs on exposed ports for local developement

### DIFF
--- a/docs/guide/src/development/local-development.md
+++ b/docs/guide/src/development/local-development.md
@@ -34,10 +34,17 @@ cp ./configs/.env.dev .env
 docker compose up --build
 ```
 
-Don't forget the `--build` flag, or you'll be running the last built image instead of the Dockerfile's build target
-that we've specified in the [docker-compose.yaml](https://github.com/USEPA/haztrak/blob/main/docker-compose.yaml) file.
+*You may find that after some changes (e.g., to the database) you need to rebuild the containers instead of restarting them. 
+In that case, use the  `--build` flag, or you'll be running the last built image instead of the Dockerfile's build target
+that we've specified in the [docker-compose.yaml](https://github.com/USEPA/haztrak/blob/main/docker-compose.yaml) file.*
 
-## Fixtures
+After all containers are successfully running (you can inspect with `docker ps`), visit one of the following
+
+- [localhost:3000](http://localhost:3000) to visit the browser client (React.js application)
+- [localhost:8000/admin](http://localhost:8000/admin) to login to the admin interface
+- The database will be exposed on port `5432` and Redis will be exposed on port `6379` of your local machine. 
+
+## Fixtures (logging in)
 
 - On start, fixtures will be loaded to the database, including 2 users to aid local development.
 


### PR DESCRIPTION
Adds a short blurb for newcomers to get up and running on their local machine about how the app is exposed on their local machine.

## Description


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
