### PR TITLE
Python 3.12 migration

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11', '3.12']
 
     services:
       postgres:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM python:3.11.6-alpine3.18 as builder
+FROM python:3.12.0-alpine3.18 as builder
 LABEL maintainer="graham.david@epa.gov"
 ENV APP_DIRECTORY=/app/
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.7.2
 Django==4.2.7
 django-celery-results==2.5.1
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
 django-extensions==3.2.3
 django-celery-beat==2.5.0
 djangorestframework==3.14.0
@@ -12,7 +12,7 @@ pytz==2023.3
 sqlparse==0.4.4
 tzdata==2023.3
 whitenoise==6.6.0
-celery==5.3.4
+celery==5.3.5
 redis==5.0.1
 drf-spectacular==0.26.5
 django-health-check==3.17.0

--- a/server/requirements_dev.txt
+++ b/server/requirements_dev.txt
@@ -2,12 +2,12 @@ pytest-mock==3.12.0
 pre-commit==3.5.0
 pytest==7.4.3
 pytest-django==4.7.0
-responses==0.23.3
+responses==0.24.1
 ruff==0.1.5
 celery-types==0.20.0
 djangorestframework-stubs==3.14.4
 ruff-lsp==0.0.45
 django-stubs==4.2.6
 django-stubs-ext==4.2.5
-Faker==20.0.0
+Faker==20.0.3
 -r requirements.txt


### PR DESCRIPTION
## Description
since Celery 5.3.5 supports python 3.12 we can safely migrate the codebase to python 3.12. Yippee! 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
