### PR TITLE
UseProgressTracker hook during manifest sync

### DIFF
--- a/client/src/components/HaztrakSite/SiteTable.tsx
+++ b/client/src/components/HaztrakSite/SiteTable.tsx
@@ -1,10 +1,8 @@
-import { Table } from 'react-bootstrap';
-import { HtTooltip } from 'components/Ht';
-import { Link } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEye, faFileLines } from '@fortawesome/free-solid-svg-icons';
-import React from 'react';
 import { HaztrakSite } from 'components/HaztrakSite/haztrakSiteSchema';
+import { SiteTableRowActions } from 'components/HaztrakSite/SiteTableRowActions';
+import React from 'react';
+import { Table } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 
 interface HtSiteTableProps {
   sitesData: Array<HaztrakSite>;
@@ -15,8 +13,9 @@ export function HtSiteTable({ sitesData }: HtSiteTableProps) {
     <Table striped hover>
       <thead>
         <tr>
-          <th>Site Alias</th>
+          <th>Site</th>
           <th>EPA ID number</th>
+          <th>Site Type</th>
           <th className="d-grid justify-content-center">Actions</th>
         </tr>
       </thead>
@@ -24,22 +23,15 @@ export function HtSiteTable({ sitesData }: HtSiteTableProps) {
         {sitesData.map((site, i) => {
           return (
             <tr key={i}>
-              <td>{site.name}</td>
+              <td>
+                <Link to={`/site/${site.handler.epaSiteId}`} aria-label={`site ${site.name}`}>
+                  {site.name}
+                </Link>
+              </td>
               <td>{site.handler.epaSiteId}</td>
+              <td>{site.handler.siteType}</td>
               <td className="d-flex justify-content-evenly">
-                <HtTooltip text={`${site.name} Details`}>
-                  <Link to={`/site/${site.handler.epaSiteId}`} aria-label={`${site.name}Details`}>
-                    <FontAwesomeIcon icon={faEye} />
-                  </Link>
-                </HtTooltip>
-                <HtTooltip text={`${site.name}'s manifest`}>
-                  <Link
-                    to={`/site/${site.handler.epaSiteId}/manifest`}
-                    aria-label={`${site.name}Manifests`}
-                  >
-                    <FontAwesomeIcon icon={faFileLines} />
-                  </Link>
-                </HtTooltip>
+                <SiteTableRowActions siteId={site.handler.epaSiteId} />
               </td>
             </tr>
           );

--- a/client/src/components/HaztrakSite/SiteTableRowActions.tsx
+++ b/client/src/components/HaztrakSite/SiteTableRowActions.tsx
@@ -1,11 +1,11 @@
-import { faEllipsisVertical, faEye, faPen } from '@fortawesome/free-solid-svg-icons';
+import { faEllipsisVertical, faEye, faFileLines } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { MouseEventHandler, ReactElement } from 'react';
 import { Col, Dropdown, Row } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 
-interface MtnRowActionsProps {
-  mtn: string;
+interface SiteTableRowActionsProps {
+  siteId: string;
 }
 
 interface RowDropdownItems {
@@ -16,35 +16,40 @@ interface RowDropdownItems {
   label: string;
 }
 
-export function MtnRowActions({ mtn }: MtnRowActionsProps) {
+/**
+ * TransporterRowActions uses index and length to disable and display
+ * different actions for eah row, expected to be part of a mapped table or list.
+ * @constructor
+ */
+export function SiteTableRowActions({ siteId }: SiteTableRowActionsProps) {
   const navigate = useNavigate();
 
   const actions: RowDropdownItems[] = [
     {
-      text: 'View ',
+      text: 'View Site',
       icon: <FontAwesomeIcon icon={faEye} className="text-primary" />,
       onClick: () => {
-        navigate(`./${mtn}/view`);
+        navigate(`/site/${siteId}`);
       },
       disabled: false,
-      label: 'View',
+      label: 'View Site',
     },
     {
-      text: 'Edit',
-      icon: <FontAwesomeIcon icon={faPen} className="text-primary" />,
+      text: 'View Manifests',
+      icon: <FontAwesomeIcon icon={faFileLines} className="text-primary" />,
       onClick: () => {
-        navigate(`./${mtn}/edit`);
+        navigate(`/site/${siteId}/manifest`);
       },
       disabled: false,
-      label: 'Edit',
+      label: 'View Site Manifests',
     },
   ];
 
   return (
-    <div className="d-flex justify-content-evenly">
+    <>
       <Dropdown>
         <Dropdown.Toggle
-          title={`${mtn} actions`}
+          title={`${siteId} actions`}
           className="bg-transparent border-0 text-dark no-caret justify-content-end"
         >
           <FontAwesomeIcon icon={faEllipsisVertical} className="pe-2 shadow-none" />
@@ -69,6 +74,6 @@ export function MtnRowActions({ mtn }: MtnRowActionsProps) {
           })}
         </Dropdown.Menu>
       </Dropdown>
-    </div>
+    </>
   );
 }

--- a/client/src/components/Manifest/Transporter/TransporterRowActions.tsx
+++ b/client/src/components/Manifest/Transporter/TransporterRowActions.tsx
@@ -29,7 +29,7 @@ interface RowDropdownItems {
  * different actions for eah row, expected to be part of a mapped table or list.
  * @constructor
  */
-function TransporterRowActions({
+export function TransporterRowActions({
   index,
   removeTransporter,
   swapTransporter,
@@ -107,5 +107,3 @@ function TransporterRowActions({
     </>
   );
 }
-
-export { TransporterRowActions };

--- a/client/src/components/Mtn/MtnTable.tsx
+++ b/client/src/components/Mtn/MtnTable.tsx
@@ -1,3 +1,5 @@
+import { faSort, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { rankItem } from '@tanstack/match-sorter-utils';
 import {
   CellContext,
@@ -20,8 +22,6 @@ import React, { useState } from 'react';
 import { Button, Col, Form, Table } from 'react-bootstrap';
 import Select from 'react-select';
 import { z } from 'zod';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSort, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
 
 const mtnDetailsSchema = z.object({
   manifestTrackingNumber: z.string(),
@@ -224,8 +224,6 @@ export function MtnTable({ manifests }: MtnTableProps) {
                       </Button>
                     )
                   ) : (
-                    // If column is defined a 'display' in our ColumnDef (columnHelpers)
-                    // Just display the 'Header' value as a string
                     <div className="text-center">
                       {flexRender(header.column.columnDef.header, header.getContext())}
                     </div>
@@ -239,7 +237,9 @@ export function MtnTable({ manifests }: MtnTableProps) {
           {table.getRowModel().rows.map((row) => (
             <tr key={row.id}>
               {row.getVisibleCells().map((cell) => (
-                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+                <td className="py-1" key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
               ))}
             </tr>
           ))}

--- a/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
+++ b/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
@@ -2,13 +2,17 @@ import { faSync } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { AxiosError } from 'axios';
 import { RcraApiUserBtn } from 'components/buttons';
-import React, { useState } from 'react';
+import { useProgressTracker } from 'hooks';
+import React, { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
 import { manifestApi } from 'services/manifestApi';
+import { addTask, useAppDispatch } from 'store';
 
 interface SyncManifestProps {
   siteId?: string;
   disabled?: boolean;
+  syncInProgress?: boolean;
+  setSyncInProgress?: (inProgress: boolean) => void;
 }
 
 /**
@@ -16,22 +20,42 @@ interface SyncManifestProps {
  * The button will be disabled if siteId (the EPA ID number) is not provided
  * @constructor
  */
-export function SyncManifestBtn({ siteId, disabled }: SyncManifestProps) {
-  const [syncingMtn, setSyncingMtn] = useState(false);
+export function SyncManifestBtn({
+  siteId,
+  disabled,
+  setSyncInProgress,
+  syncInProgress,
+}: SyncManifestProps) {
+  const dispatch = useAppDispatch();
+  const [taskId, setTaskId] = useState<string | undefined>(undefined);
+  const { inProgress, error } = useProgressTracker({ taskId: taskId });
+
+  useEffect(() => {
+    if (setSyncInProgress) setSyncInProgress(inProgress);
+  }, [inProgress]);
 
   return (
     <RcraApiUserBtn
       variant="primary"
-      disabled={disabled || !siteId || syncingMtn}
+      disabled={disabled || !siteId || inProgress}
       className="mx-2"
       onClick={() => {
-        setSyncingMtn(!syncingMtn);
         if (siteId)
           manifestApi
             .syncManifest(siteId)
             .then((response) => {
-              toast.info(`Syncing Manifests for ${siteId}`);
+              dispatch(
+                addTask({
+                  taskId: response.data.taskId,
+                  status: 'PENDING',
+                  taskName: 'Syncing RCRAInfo Profile',
+                })
+              );
+              setTaskId(response.data.taskId);
             })
+            // .then((response) => {
+            //   toast.info(`Syncing Manifests for ${siteId}`);
+            // })
             .catch((error: AxiosError) => toast.error(error.message));
       }}
     >

--- a/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
+++ b/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
@@ -4,9 +4,8 @@ import { AxiosError } from 'axios';
 import { RcraApiUserBtn } from 'components/buttons';
 import { useProgressTracker } from 'hooks';
 import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
 import { manifestApi } from 'services/manifestApi';
-import { addTask, useAppDispatch } from 'store';
+import { addTask, updateTask, useAppDispatch } from 'store';
 
 interface SyncManifestProps {
   siteId?: string;
@@ -53,10 +52,14 @@ export function SyncManifestBtn({
               );
               setTaskId(response.data.taskId);
             })
-            // .then((response) => {
-            //   toast.info(`Syncing Manifests for ${siteId}`);
-            // })
-            .catch((error: AxiosError) => toast.error(error.message));
+            .catch((error: AxiosError) =>
+              dispatch(
+                updateTask({
+                  taskId: taskId,
+                  status: 'FAILURE',
+                })
+              )
+            );
       }}
     >
       {`Sync Manifest `}

--- a/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
+++ b/client/src/components/buttons/SyncManifestBtn/SyncManifestBtn.tsx
@@ -63,7 +63,7 @@ export function SyncManifestBtn({
       }}
     >
       {`Sync Manifest `}
-      <FontAwesomeIcon icon={faSync} />
+      <FontAwesomeIcon icon={faSync} spin={syncInProgress} />
     </RcraApiUserBtn>
   );
 }

--- a/client/src/features/SiteList/SiteList.tsx
+++ b/client/src/features/SiteList/SiteList.tsx
@@ -25,15 +25,11 @@ export function SiteList() {
       <HtCard>
         <HtCard.Header title="My Sites" />
         <HtCard.Body>
-          {/* if loading, show HtCard spinner component*/}
           {loading && !error ? (
             <HtCard.Spinner message="Loading your sites..." />
-          ) : //  else check if siteData is present
-          siteData ? (
-            // if yes, display the table
+          ) : siteData ? (
             <HtSiteTable sitesData={siteData} />
-          ) : // else check if there's an error
-          error ? (
+          ) : error ? (
             <>
               <HtModal showModal={showErrorModal} handleClose={handleClose}>
                 <HtModal.Header closeButton>

--- a/client/src/features/manifestList/ManifestList.tsx
+++ b/client/src/features/manifestList/ManifestList.tsx
@@ -6,39 +6,22 @@ import { useTitle } from 'hooks';
 import React, { ReactElement, useState } from 'react';
 import { Col, Container, Row } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
-import { useGetMTNQuery } from 'store';
+import { useAppDispatch, useGetMTNQuery } from 'store';
 
 /**
  * Fetch and display all the manifest tracking number (MTN) known by haztrak
  * @constructor
  */
 export function ManifestList(): ReactElement {
+  const dispatch = useAppDispatch();
   let { siteId } = useParams();
   useTitle(`${siteId || ''} Manifest`);
   const [pageSize, setPageSize] = useState(10);
   const [syncInProgress, setSyncInProgress] = useState(false);
 
-  let getUrl = 'rcra/mtn';
-  if (siteId) {
-    getUrl = `rcra/mtn/${siteId}`;
-  }
-
-  // const [mtnList, loading, error] = useHtApi<Array<MtnDetails>>(getUrl);
-
   const { data, isLoading, error } = useGetMTNQuery(siteId, {
-    pollingInterval: 1000,
-    skip: !syncInProgress,
+    pollingInterval: syncInProgress ? 1000 : 0,
   });
-
-  const mtnList = data;
-  const loading = isLoading;
-
-  if (error) {
-    throw error;
-  }
-
-  console.log('syncInProgress', syncInProgress);
-  console.log('data', data);
 
   return (
     <Container className="py-2">
@@ -63,10 +46,10 @@ export function ManifestList(): ReactElement {
           <HtCard>
             <HtCard.Header title={`${siteId || 'Your'} Manifests`}></HtCard.Header>
             <HtCard.Body>
-              {loading ? (
+              {isLoading ? (
                 <HtCard.Spinner />
-              ) : mtnList ? (
-                <MtnTable manifests={mtnList} pageSize={pageSize} />
+              ) : data ? (
+                <MtnTable manifests={data} pageSize={pageSize} />
               ) : (
                 <></>
               )}

--- a/client/src/features/manifestList/ManifestList.tsx
+++ b/client/src/features/manifestList/ManifestList.tsx
@@ -1,11 +1,12 @@
 import { SyncManifestBtn } from 'components/buttons';
 import { NewManifestBtn } from 'components/buttons/NewManifestBtn';
 import { HtCard } from 'components/Ht';
-import { MtnDetails, MtnTable } from 'components/Mtn';
-import { useHtApi, useTitle } from 'hooks';
+import { MtnTable } from 'components/Mtn';
+import { useTitle } from 'hooks';
 import React, { ReactElement, useState } from 'react';
 import { Col, Container, Row } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
+import { useGetMTNQuery } from 'store';
 
 /**
  * Fetch and display all the manifest tracking number (MTN) known by haztrak
@@ -15,18 +16,29 @@ export function ManifestList(): ReactElement {
   let { siteId } = useParams();
   useTitle(`${siteId || ''} Manifest`);
   const [pageSize, setPageSize] = useState(10);
+  const [syncInProgress, setSyncInProgress] = useState(false);
 
   let getUrl = 'rcra/mtn';
   if (siteId) {
     getUrl = `rcra/mtn/${siteId}`;
   }
 
-  const [mtnList, loading, error] = useHtApi<Array<MtnDetails>>(getUrl);
+  // const [mtnList, loading, error] = useHtApi<Array<MtnDetails>>(getUrl);
+
+  const { data, isLoading, error } = useGetMTNQuery(siteId, {
+    pollingInterval: 1000,
+    skip: !syncInProgress,
+  });
+
+  const mtnList = data;
+  const loading = isLoading;
 
   if (error) {
-    console.error(error.message);
     throw error;
   }
+
+  console.log('syncInProgress', syncInProgress);
+  console.log('data', data);
 
   return (
     <Container className="py-2">
@@ -36,7 +48,12 @@ export function ManifestList(): ReactElement {
             <h2>{siteId}</h2>
           </Col>
           <Col className="d-flex justify-content-end" xl>
-            <SyncManifestBtn siteId={siteId} disabled={!siteId} />
+            <SyncManifestBtn
+              siteId={siteId}
+              disabled={!siteId}
+              syncInProgress={syncInProgress}
+              setSyncInProgress={setSyncInProgress}
+            />
             <NewManifestBtn siteId={siteId} />
           </Col>
         </Row>

--- a/client/src/hooks/useProgressTracker/useProgressTracker.tsx
+++ b/client/src/hooks/useProgressTracker/useProgressTracker.tsx
@@ -62,7 +62,6 @@ export function useProgressTracker({
 
   //
   useEffect(() => {
-    console.log('taskComplete', taskComplete);
     if (taskComplete) {
       if (reduxAction) dispatch(reduxAction);
       setInProgress(false);

--- a/client/src/store/haztrakApiSlice.ts
+++ b/client/src/store/haztrakApiSlice.ts
@@ -2,6 +2,7 @@ import { BaseQueryFn, createApi } from '@reduxjs/toolkit/dist/query/react';
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { HaztrakSite } from 'components/HaztrakSite';
 import { Code } from 'components/Manifest/WasteLine/wasteLineSchema';
+import { MtnDetails } from 'components/Mtn';
 import { RcraSite } from 'components/RcraSite';
 import { htApi } from 'services';
 
@@ -101,7 +102,10 @@ export const haztrakApi = createApi({
       query: (id) => ({ url: 'rcra/waste/dot/id', method: 'get', params: { q: id } }),
     }),
     getOrgSites: build.query<Array<HaztrakSite>, string>({
-      query: (id) => ({ url: `org/${id}/site`, method: 'get', params: { q: id } }),
+      query: (id) => ({ url: `org/${id}/site`, method: 'get' }),
+    }),
+    getMTN: build.query<Array<MtnDetails>, string | undefined>({
+      query: (siteId) => ({ url: siteId ? `rcra/mtn/${siteId}` : '/rcra/mtn', method: 'get' }),
     }),
   }),
 });
@@ -114,4 +118,5 @@ export const {
   useGetStateWasteCodesQuery,
   useGetDotIdNumbersQuery,
   useGetOrgSitesQuery,
+  useGetMTNQuery,
 } = haztrakApi;

--- a/client/src/store/haztrakApiSlice.ts
+++ b/client/src/store/haztrakApiSlice.ts
@@ -105,7 +105,7 @@ export const haztrakApi = createApi({
       query: (id) => ({ url: `org/${id}/site`, method: 'get' }),
     }),
     getMTN: build.query<Array<MtnDetails>, string | undefined>({
-      query: (siteId) => ({ url: siteId ? `rcra/mtn/${siteId}` : '/rcra/mtn', method: 'get' }),
+      query: (siteId) => ({ url: siteId ? `rcra/mtn/${siteId}` : 'rcra/mtn', method: 'get' }),
     }),
   }),
 });

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -18,6 +18,7 @@ export {
   useSearchRcrainfoSitesQuery,
   useSearchRcraSitesQuery,
   useGetOrgSitesQuery,
+  useGetMTNQuery,
 } from 'store/haztrakApiSlice';
 
 // Authentication Slice

--- a/server/apps/sites/services/site_services.py
+++ b/server/apps/sites/services/site_services.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import UTC, datetime
-from typing import Optional, TypedDict
+from typing import Optional
 
 from django.db import transaction
 


### PR DESCRIPTION
## Description
Uses our new custom hook (that I'm very happy with and proud of LOL) to track long-running task progress while syncing a site's manifests. in addition, we pass state of the sync progress to the sync manifest button, allowing us to poll the server while the task is running and display newly added manifest as they are added. Also some UI candy like spinning the site sync icon. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
