### PR TITLE
Scheduled status disabling

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -5,3 +5,4 @@ node_modules/
 **/.vscode
 **/.idea
 **/*.bak
+/coverage

--- a/client/src/components/Manifest/Actions/ManifestFABs.tsx
+++ b/client/src/components/Manifest/Actions/ManifestFABs.tsx
@@ -11,7 +11,7 @@ interface ManifestActionBtnsProps {
 }
 
 export function ManifestFABs({ onSignClick }: ManifestActionBtnsProps) {
-  const { nextSigningSite, readOnly, status, signAble } = useContext(ManifestContext);
+  const { nextSigningSite, readOnly, signAble } = useContext(ManifestContext);
   const rcraSiteType = manifest.siteTypeToRcraSiteType(nextSigningSite?.siteType);
   let component: ReactElement | undefined = undefined;
   if (!readOnly) {

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.spec.tsx
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
+import { afterEach, describe, expect, test } from 'vitest';
+import { GeneralInfoForm } from './GeneralInfoForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Manifest General Info Form', () => {
+  test('renders', () => {
+    renderWithProviders(
+      <GeneralInfoForm isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
+    );
+  });
+  test('is editable if not readOnly', () => {
+    renderWithProviders(
+      <GeneralInfoForm isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
+    );
+    expect(screen.getByLabelText(/Potential Ship Date/i)).toBeEnabled();
+  });
+});

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.spec.tsx
@@ -10,14 +10,10 @@ afterEach(() => {
 
 describe('Manifest General Info Form', () => {
   test('renders', () => {
-    renderWithProviders(
-      <GeneralInfoForm isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
-    );
+    renderWithProviders(<GeneralInfoForm isDraft={true} readOnly={false} />);
   });
   test('is editable if not readOnly', () => {
-    renderWithProviders(
-      <GeneralInfoForm isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
-    );
+    renderWithProviders(<GeneralInfoForm isDraft={true} readOnly={false} />);
     expect(screen.getByLabelText(/Potential Ship Date/i)).toBeEnabled();
   });
 });

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
@@ -9,15 +9,9 @@ interface GeneralInfoFormProps {
   manifestData?: Partial<Manifest>;
   readOnly?: boolean;
   isDraft?: boolean;
-  setManifestStatus: (status: ManifestStatus | undefined) => void;
 }
 
-export function GeneralInfoForm({
-  manifestData,
-  readOnly,
-  isDraft,
-  setManifestStatus,
-}: GeneralInfoFormProps) {
+export function GeneralInfoForm({ manifestData, readOnly, isDraft }: GeneralInfoFormProps) {
   const manifestForm = useFormContext<Manifest>();
   const { errors } = manifestForm.formState;
   return (
@@ -43,11 +37,7 @@ export function GeneralInfoForm({
           </HtForm.Group>
         </Col>
         <Col>
-          <ManifestStatusField
-            setManifestStatus={setManifestStatus}
-            readOnly={readOnly}
-            isDraft={isDraft}
-          />
+          <ManifestStatusField readOnly={readOnly} isDraft={isDraft} />
         </Col>
         <Col>
           <HtForm.Group>

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
@@ -1,15 +1,23 @@
 import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestStatusField';
-import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
+import { Manifest, SubmissionType } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
 import { useFormContext } from 'react-hook-form';
+import Select from 'react-select';
 
 interface GeneralInfoFormProps {
   manifestData?: Partial<Manifest>;
   readOnly?: boolean;
   isDraft?: boolean;
 }
+
+const submissionTypeOptions: Array<{ value: SubmissionType; label: string }> = [
+  { value: 'FullElectronic', label: 'Electronic' },
+  { value: 'Hybrid', label: 'Hybrid' },
+  { value: 'DataImage5Copy', label: 'Data + Image' },
+  { value: 'Image', label: 'Image Only' },
+];
 
 export function GeneralInfoForm({ manifestData, readOnly, isDraft }: GeneralInfoFormProps) {
   const manifestForm = useFormContext<Manifest>();
@@ -44,21 +52,24 @@ export function GeneralInfoForm({ manifestData, readOnly, isDraft }: GeneralInfo
             <HtForm.Label htmlFor="submissionType" className="mb-0">
               Type
             </HtForm.Label>
-            <HtForm.Select
+            <Select
               id="submissionType"
-              disabled={readOnly || !isDraft}
+              isDisabled={readOnly || !isDraft}
               aria-label="submissionType"
               {...manifestForm.register('submissionType')}
-            >
-              <option value="FullElectronic">Electronic</option>
-              <option value="Hybrid">Hybrid</option>
-              <option hidden value="DataImage5Copy">
-                Data + Image
-              </option>
-              <option hidden value="Image">
-                Image Only
-              </option>
-            </HtForm.Select>
+              options={submissionTypeOptions}
+              getOptionValue={(option) => option.value}
+              defaultValue={submissionTypeOptions[0]}
+              onChange={(option) => {
+                if (option) manifestForm.setValue('submissionType', option.value);
+              }}
+              filterOption={(option) => {
+                return (
+                  option.label.toLowerCase().includes('electronic') ||
+                  option.label.toLowerCase().includes('hybrid')
+                );
+              }}
+            />
           </HtForm.Group>
         </Col>
       </Row>

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
@@ -1,3 +1,4 @@
+import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestStatusField';
 import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
 import React from 'react';
@@ -42,45 +43,11 @@ export function GeneralInfoForm({
           </HtForm.Group>
         </Col>
         <Col>
-          <HtForm.Group>
-            <HtForm.Label htmlFor="status" className="mb-0">
-              {'Status '}
-              {!isDraft && (
-                <InfoIconTooltip message={'Once set to scheduled, this field is managed by EPA'} />
-              )}
-            </HtForm.Label>
-            <HtForm.Select
-              id="status"
-              disabled={readOnly || !isDraft}
-              aria-label="manifestStatus"
-              {...manifestForm.register('status')}
-              onChange={(event) =>
-                setManifestStatus(event.target.value as ManifestStatus | undefined)
-              }
-            >
-              <option value="NotAssigned">Draft</option>
-              <option value="Pending">Pending</option>
-              <option value="Scheduled">Scheduled</option>
-              <option hidden value="InTransit">
-                In Transit
-              </option>
-              <option hidden value="ReadyForSignature">
-                Ready for TSDF Signature
-              </option>
-              <option hidden value="Signed">
-                Signed
-              </option>
-              <option hidden value="Corrected">
-                Corrected
-              </option>
-              <option hidden value="UnderCorrection">
-                Under Correction
-              </option>
-              <option hidden value="MtnValidationFailed">
-                MTN Validation Failed
-              </option>
-            </HtForm.Select>
-          </HtForm.Group>
+          <ManifestStatusField
+            setManifestStatus={setManifestStatus}
+            readOnly={readOnly}
+            isDraft={isDraft}
+          />
         </Col>
         <Col>
           <HtForm.Group>

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
@@ -1,0 +1,202 @@
+import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
+import { HtForm, InfoIconTooltip } from 'components/UI';
+import React from 'react';
+import { Col, Form, Row } from 'react-bootstrap';
+import { useFormContext } from 'react-hook-form';
+
+interface GeneralInfoFormProps {
+  manifestData?: Partial<Manifest>;
+  readOnly?: boolean;
+  isDraft?: boolean;
+  setManifestStatus: (status: ManifestStatus | undefined) => void;
+}
+
+export function GeneralInfoForm({
+  manifestData,
+  readOnly,
+  isDraft,
+  setManifestStatus,
+}: GeneralInfoFormProps) {
+  const manifestForm = useFormContext<Manifest>();
+  const { errors } = manifestForm.formState;
+  return (
+    <>
+      <Row>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="manifestTrackingNumber">MTN</HtForm.Label>
+            <Form.Control
+              id="manifestTrackingNumber"
+              plaintext
+              readOnly
+              type="text"
+              placeholder={
+                !manifestData?.manifestTrackingNumber
+                  ? 'Draft Manifest'
+                  : manifestData?.manifestTrackingNumber
+              }
+              {...manifestForm.register('manifestTrackingNumber')}
+              className={errors.manifestTrackingNumber && 'is-invalid'}
+            />
+            <div className="invalid-feedback">{errors.manifestTrackingNumber?.message}</div>
+          </HtForm.Group>
+        </Col>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="status" className="mb-0">
+              {'Status '}
+              {!isDraft && (
+                <InfoIconTooltip message={'Once set to scheduled, this field is managed by EPA'} />
+              )}
+            </HtForm.Label>
+            <HtForm.Select
+              id="status"
+              disabled={readOnly || !isDraft}
+              aria-label="manifestStatus"
+              {...manifestForm.register('status')}
+              onChange={(event) =>
+                setManifestStatus(event.target.value as ManifestStatus | undefined)
+              }
+            >
+              <option value="NotAssigned">Draft</option>
+              <option value="Pending">Pending</option>
+              <option value="Scheduled">Scheduled</option>
+              <option hidden value="InTransit">
+                In Transit
+              </option>
+              <option hidden value="ReadyForSignature">
+                Ready for TSDF Signature
+              </option>
+              <option hidden value="Signed">
+                Signed
+              </option>
+              <option hidden value="Corrected">
+                Corrected
+              </option>
+              <option hidden value="UnderCorrection">
+                Under Correction
+              </option>
+              <option hidden value="MtnValidationFailed">
+                MTN Validation Failed
+              </option>
+            </HtForm.Select>
+          </HtForm.Group>
+        </Col>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="submissionType" className="mb-0">
+              Type
+            </HtForm.Label>
+            <HtForm.Select
+              id="submissionType"
+              disabled={readOnly || !isDraft}
+              aria-label="submissionType"
+              {...manifestForm.register('submissionType')}
+            >
+              <option value="FullElectronic">Electronic</option>
+              <option value="Hybrid">Hybrid</option>
+              <option hidden value="DataImage5Copy">
+                Data + Image
+              </option>
+              <option hidden value="Image">
+                Image Only
+              </option>
+            </HtForm.Select>
+          </HtForm.Group>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="createdDate">
+              {'Created Date '}
+              <InfoIconTooltip message={'This field is managed by EPA'} />
+            </HtForm.Label>
+            <Form.Control
+              id="createdDate"
+              aria-label={'created date'}
+              plaintext
+              disabled
+              type="date"
+              value={manifestData?.createdDate?.slice(0, 10)}
+              {...manifestForm.register('createdDate')}
+              className={errors.createdDate && 'is-invalid'}
+            />
+            <div className="invalid-feedback">{errors.createdDate?.message}</div>
+          </HtForm.Group>
+        </Col>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="updatedDate">
+              {'Last Update Date '}
+              <InfoIconTooltip message={'This field is managed by EPA'} />
+            </HtForm.Label>
+            <Form.Control
+              id="updatedDate"
+              plaintext
+              disabled
+              type="date"
+              value={manifestData?.updatedDate?.slice(0, 10)}
+              {...manifestForm.register('updatedDate')}
+              className={errors.updatedDate && 'is-invalid'}
+            />
+            <div className="invalid-feedback">{errors.updatedDate?.message}</div>
+          </HtForm.Group>
+        </Col>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="shippedDate">
+              {'Shipped Date '}
+              <InfoIconTooltip message={'This field is managed by EPA'} />
+            </HtForm.Label>
+            <Form.Control
+              id="shippedDate"
+              disabled
+              plaintext
+              type="date"
+              value={manifestData?.shippedDate?.slice(0, 10)}
+              {...manifestForm.register('shippedDate')}
+              className={errors.shippedDate && 'is-invalid'}
+            />
+            <div className="invalid-feedback">{errors.shippedDate?.message?.toString()}</div>
+          </HtForm.Group>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <HtForm.Check
+            type="checkbox"
+            id="import"
+            disabled={readOnly}
+            label="Imported Waste"
+            {...manifestForm.register('import')}
+            className={errors.import && 'is-invalid'}
+          />
+          <div className="invalid-feedback">{errors.import?.message}</div>
+          <HtForm.Check
+            type="checkbox"
+            id="rejection"
+            disabled={readOnly}
+            label="Rejected Waste"
+            {...manifestForm.register('rejection')}
+            className={errors.rejection && 'is-invalid'}
+          />
+          <div className="invalid-feedback">{errors.rejection?.message}</div>
+        </Col>
+        <Col>
+          <HtForm.Group>
+            <HtForm.Label htmlFor="potentialShipDate">Potential Ship Date</HtForm.Label>
+            <Form.Control
+              id="potentialShipDate"
+              disabled={readOnly}
+              type="date"
+              {...manifestForm.register('potentialShipDate')}
+              className={errors.potentialShipDate && 'is-invalid'}
+            />
+            <div className="invalid-feedback">{errors.potentialShipDate?.message}</div>
+          </HtForm.Group>
+        </Col>
+      </Row>
+    </>
+  );
+}

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestStatusField';
+import React from 'react';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
+import { afterEach, describe, expect, test } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Manifest Status Field', () => {
+  test('renders', () => {
+    renderWithProviders(
+      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
+    );
+  });
+  test('is not editable if read only', () => {
+    renderWithProviders(
+      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={true} />
+    );
+    expect(screen.getByLabelText(/Status/i)).toBeDisabled();
+  });
+  test('is editable if the manifest is a draft', () => {
+    renderWithProviders(
+      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
+    );
+    expect(screen.getByLabelText(/Status/i)).not.toBeDisabled();
+  });
+  test('new manifest options are pending and draft if no designated facility access', () => {
+    renderWithProviders(
+      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
+    );
+    // expect(screen.getByLabelText(/Status/i)).not.toBeDisabled();
+    const options = screen.getAllByRole('option');
+    // screen.debug(undefined, Infinity);
+
+    options.forEach((option) => {
+      console.log(option);
+      expect(option).toBeVisible();
+      // if (option.textContent === 'draft' || option.textContent === 'pending') {
+      //   expect(option).toBeVisible()
+      // } else {
+      //   expect(option).not.toBeVisible();
+      // }
+    });
+  });
+});

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
@@ -3,8 +3,6 @@ import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestSta
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { afterEach, describe, expect, test } from 'vitest';
-import { Manifest } from 'components/Manifest/manifestSchema';
-import { useFormContext } from 'react-hook-form';
 
 afterEach(() => {
   cleanup();
@@ -12,47 +10,29 @@ afterEach(() => {
 
 interface TestComponentProps {
   isDraft?: boolean;
-  setManifestStatus?: (status: string | undefined) => void;
   readOnly?: boolean;
 }
 
-const TestComponent = ({ isDraft, setManifestStatus, readOnly }: TestComponentProps) => {
-  const setStatusFn = setManifestStatus ? setManifestStatus : () => undefined;
+const TestComponent = ({ isDraft, readOnly }: TestComponentProps) => {
   const isDraftVal = isDraft !== undefined ? isDraft : true;
   const readOnlyVal = readOnly !== undefined ? readOnly : false;
   return (
     <>
-      <ManifestStatusField
-        isDraft={isDraftVal}
-        setManifestStatus={setStatusFn}
-        readOnly={readOnlyVal}
-      />
+      <ManifestStatusField isDraft={isDraftVal} readOnly={readOnlyVal} />
     </>
   );
 };
 
 describe('Manifest Status Field', () => {
   test('renders', () => {
-    renderWithProviders(
-      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
-    );
+    renderWithProviders(<ManifestStatusField isDraft={true} readOnly={false} />);
   });
   test('is not editable if read only', () => {
-    renderWithProviders(
-      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={true} />
-    );
+    renderWithProviders(<ManifestStatusField isDraft={true} readOnly={true} />);
     expect(screen.getByLabelText(/Status/i)).toBeDisabled();
   });
   test('is editable if the manifest is a draft', () => {
-    renderWithProviders(
-      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
-    );
+    renderWithProviders(<ManifestStatusField isDraft={true} readOnly={false} />);
     expect(screen.getByLabelText(/Status/i)).not.toBeDisabled();
-  });
-  test('new manifest are draft by default', async () => {
-    renderWithProviders(<TestComponent />);
-    const combobox = screen.getByRole('combobox');
-    expect(combobox).toHaveValue('NotAssigned');
-    expect(combobox).toBeEnabled();
   });
 });

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
@@ -2,11 +2,19 @@ import '@testing-library/jest-dom';
 import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestStatusField';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { userApiMocks } from 'test-utils/mock';
+import { http, HttpResponse } from 'msw';
+import { createMockProfileResponse } from 'test-utils/fixtures/mockUser';
+import { API_BASE_URL } from 'test-utils/mock/htApiMocks';
+import { createMockHandler, createMockSite } from 'test-utils/fixtures';
 
-afterEach(() => {
-  cleanup();
-});
+const server = setupServer(...userApiMocks);
+afterEach(() => cleanup());
+beforeAll(() => server.listen());
+afterAll(() => server.close()); // Disable API mocking after the tests are done.
 
 interface TestComponentProps {
   isDraft?: boolean;
@@ -25,14 +33,92 @@ const TestComponent = ({ isDraft, readOnly }: TestComponentProps) => {
 
 describe('Manifest Status Field', () => {
   test('renders', () => {
-    renderWithProviders(<ManifestStatusField isDraft={true} readOnly={false} />);
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />);
   });
   test('is not editable if read only', () => {
-    renderWithProviders(<ManifestStatusField isDraft={true} readOnly={true} />);
+    renderWithProviders(<TestComponent isDraft={true} readOnly={true} />);
     expect(screen.getByLabelText(/Status/i)).toBeDisabled();
   });
   test('is editable if the manifest is a draft', () => {
-    renderWithProviders(<ManifestStatusField isDraft={true} readOnly={false} />);
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />);
     expect(screen.getByLabelText(/Status/i)).not.toBeDisabled();
+  });
+  test('Scheduled status is enabled if user has access to TSDF', async () => {
+    // Arrange
+    const userGeneratorSite = createMockSite({
+      handler: createMockHandler({
+        siteType: 'Generator',
+        epaSiteId: 'MOCKVAGEN001',
+      }),
+    });
+    const userTsdfSite = createMockSite({
+      handler: createMockHandler({
+        siteType: 'Tsdf',
+        epaSiteId: 'MOCKVATSDF001',
+      }),
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/api/user/profile`, () => {
+        return HttpResponse.json(
+          {
+            ...createMockProfileResponse({
+              sites: [
+                {
+                  site: userGeneratorSite,
+                  eManifest: 'signer',
+                },
+                {
+                  site: userTsdfSite,
+                  eManifest: 'signer',
+                },
+              ],
+            }),
+          },
+          { status: 200 }
+        );
+      })
+    );
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />, {
+      preloadedState: { manifest: { readOnly: false } },
+      useFormProps: { values: { status: 'NotAssigned', generator: userGeneratorSite.handler } },
+    });
+    await userEvent.click(screen.getByLabelText(/Status/i));
+    const options = screen.queryAllByRole('option');
+    const scheduledOption = options.find((option) => option.textContent === 'Scheduled');
+    expect(scheduledOption).not.toBeDisabled();
+  });
+  test('Scheduled status is disabled if no access to TSDF', async () => {
+    // Arrange
+    const userGeneratorSite = createMockSite({
+      handler: createMockHandler({
+        siteType: 'Generator',
+        epaSiteId: 'MOCKVAGEN001',
+      }),
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/api/user/profile`, () => {
+        return HttpResponse.json(
+          {
+            ...createMockProfileResponse({
+              sites: [
+                {
+                  site: userGeneratorSite,
+                  eManifest: 'signer',
+                },
+              ],
+            }),
+          },
+          { status: 200 }
+        );
+      })
+    );
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />, {
+      preloadedState: { manifest: { readOnly: false } },
+      useFormProps: { values: { status: 'NotAssigned', generator: userGeneratorSite.handler } },
+    });
+    await userEvent.click(screen.getByLabelText(/Status/i));
+    const scheduledOption = screen.queryByRole('option', { name: /Scheduled/i });
+    expect(scheduledOption).toBeInTheDocument();
+    expect(scheduledOption).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.spec.tsx
@@ -3,10 +3,33 @@ import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestSta
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { afterEach, describe, expect, test } from 'vitest';
+import { Manifest } from 'components/Manifest/manifestSchema';
+import { useFormContext } from 'react-hook-form';
 
 afterEach(() => {
   cleanup();
 });
+
+interface TestComponentProps {
+  isDraft?: boolean;
+  setManifestStatus?: (status: string | undefined) => void;
+  readOnly?: boolean;
+}
+
+const TestComponent = ({ isDraft, setManifestStatus, readOnly }: TestComponentProps) => {
+  const setStatusFn = setManifestStatus ? setManifestStatus : () => undefined;
+  const isDraftVal = isDraft !== undefined ? isDraft : true;
+  const readOnlyVal = readOnly !== undefined ? readOnly : false;
+  return (
+    <>
+      <ManifestStatusField
+        isDraft={isDraftVal}
+        setManifestStatus={setStatusFn}
+        readOnly={readOnlyVal}
+      />
+    </>
+  );
+};
 
 describe('Manifest Status Field', () => {
   test('renders', () => {
@@ -26,22 +49,10 @@ describe('Manifest Status Field', () => {
     );
     expect(screen.getByLabelText(/Status/i)).not.toBeDisabled();
   });
-  test('new manifest options are pending and draft if no designated facility access', () => {
-    renderWithProviders(
-      <ManifestStatusField isDraft={true} setManifestStatus={() => undefined} readOnly={false} />
-    );
-    // expect(screen.getByLabelText(/Status/i)).not.toBeDisabled();
-    const options = screen.getAllByRole('option');
-    // screen.debug(undefined, Infinity);
-
-    options.forEach((option) => {
-      console.log(option);
-      expect(option).toBeVisible();
-      // if (option.textContent === 'draft' || option.textContent === 'pending') {
-      //   expect(option).toBeVisible()
-      // } else {
-      //   expect(option).not.toBeVisible();
-      // }
-    });
+  test('new manifest are draft by default', async () => {
+    renderWithProviders(<TestComponent />);
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toHaveValue('NotAssigned');
+    expect(combobox).toBeEnabled();
   });
 });

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
@@ -2,19 +2,17 @@ import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useAppDispatch } from 'store';
+import { setStatus } from 'store/manifestSlice/manifest.slice';
 
 interface ManifestStatusFieldProps {
   readOnly?: boolean;
   isDraft?: boolean;
-  setManifestStatus: (status: ManifestStatus | undefined) => void;
 }
 
-export function ManifestStatusField({
-  readOnly,
-  isDraft,
-  setManifestStatus,
-}: ManifestStatusFieldProps) {
+export function ManifestStatusField({ readOnly, isDraft }: ManifestStatusFieldProps) {
   const manifestForm = useFormContext<Manifest>();
+  const dispatch = useAppDispatch();
   return (
     <HtForm.Group>
       <HtForm.Label htmlFor="status" className="mb-0">
@@ -29,7 +27,9 @@ export function ManifestStatusField({
         aria-label="manifestStatus"
         {...manifestForm.register('status')}
         defaultValue={'NotAssigned'}
-        onChange={(event) => setManifestStatus(event.target.value as ManifestStatus | undefined)}
+        onChange={(event) => {
+          dispatch(setStatus(event.target.value as ManifestStatus));
+        }}
       >
         <option value="NotAssigned">Draft</option>
         <option value="Pending">Pending</option>

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
@@ -3,13 +3,17 @@ import { HtForm, InfoIconTooltip } from 'components/UI';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
-interface ManifestStatusProps {
+interface ManifestStatusFieldProps {
   readOnly?: boolean;
   isDraft?: boolean;
   setManifestStatus: (status: ManifestStatus | undefined) => void;
 }
 
-export function ManifestStatusField({ readOnly, isDraft, setManifestStatus }: ManifestStatusProps) {
+export function ManifestStatusField({
+  readOnly,
+  isDraft,
+  setManifestStatus,
+}: ManifestStatusFieldProps) {
   const manifestForm = useFormContext<Manifest>();
   return (
     <HtForm.Group>
@@ -24,6 +28,7 @@ export function ManifestStatusField({ readOnly, isDraft, setManifestStatus }: Ma
         disabled={readOnly || !isDraft}
         aria-label="manifestStatus"
         {...manifestForm.register('status')}
+        defaultValue={'NotAssigned'}
         onChange={(event) => setManifestStatus(event.target.value as ManifestStatus | undefined)}
       >
         <option value="NotAssigned">Draft</option>

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
@@ -2,57 +2,73 @@ import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useAppDispatch } from 'store';
-import { setStatus } from 'store/manifestSlice/manifest.slice';
+import { useAppDispatch, useAppSelector, useGetProfileQuery } from 'store';
+import { selectManifestStatus, setStatus } from 'store/manifestSlice/manifest.slice';
+import { manifest } from 'services';
+import Select, { SingleValue } from 'react-select';
+
+interface StatusOption {
+  value: ManifestStatus;
+  label: string;
+}
+
+const statusOptions: StatusOption[] = [
+  { value: 'NotAssigned', label: 'Draft' },
+  { value: 'Pending', label: 'Pending' },
+  { value: 'Scheduled', label: 'Scheduled' },
+  { value: 'InTransit', label: 'In Transit' },
+  { value: 'ReadyForSignature', label: 'Ready for TSDF Signature' },
+  { value: 'Signed', label: 'Signed' },
+  { value: 'Corrected', label: 'Corrected' },
+  { value: 'UnderCorrection', label: 'Under Correction' },
+  { value: 'MtnValidationFailed', label: 'MTN Validation Failed' },
+];
 
 interface ManifestStatusFieldProps {
   readOnly?: boolean;
   isDraft?: boolean;
 }
 
+/** uniform hazardous waste manifest status field. */
 export function ManifestStatusField({ readOnly, isDraft }: ManifestStatusFieldProps) {
-  const manifestForm = useFormContext<Manifest>();
   const dispatch = useAppDispatch();
+  const status = statusOptions.filter(
+    (value) => value.value === useAppSelector(selectManifestStatus)
+  );
+  const manifestForm = useFormContext<Manifest>();
+  const { data: profile, isLoading: profileLoading } = useGetProfileQuery();
+
+  const availableStatuses = manifest.getStatusOptions({
+    manifest: manifestForm.getValues(),
+    // @ts-ignore
+    profile: profile,
+  });
   return (
     <HtForm.Group>
       <HtForm.Label htmlFor="status" className="mb-0">
-        {'Status '}
+        <span>Status </span>
         {!isDraft && (
           <InfoIconTooltip message={'Once set to scheduled, this field is managed by EPA'} />
         )}
       </HtForm.Label>
-      <HtForm.Select
+      <Select
         id="status"
-        disabled={readOnly || !isDraft}
+        isDisabled={readOnly || !isDraft}
+        data-testid="manifestStatus"
         aria-label="manifestStatus"
         {...manifestForm.register('status')}
-        defaultValue={'NotAssigned'}
-        onChange={(event) => {
-          dispatch(setStatus(event.target.value as ManifestStatus));
+        value={status}
+        isLoading={profileLoading || !profile}
+        classNames={{
+          control: () => 'form-select py-0 rounded-3',
         }}
-      >
-        <option value="NotAssigned">Draft</option>
-        <option value="Pending">Pending</option>
-        <option value="Scheduled">Scheduled</option>
-        <option hidden value="InTransit">
-          In Transit
-        </option>
-        <option hidden value="ReadyForSignature">
-          Ready for TSDF Signature
-        </option>
-        <option hidden value="Signed">
-          Signed
-        </option>
-        <option hidden value="Corrected">
-          Corrected
-        </option>
-        <option hidden value="UnderCorrection">
-          Under Correction
-        </option>
-        <option hidden value="MtnValidationFailed">
-          MTN Validation Failed
-        </option>
-      </HtForm.Select>
+        onChange={(option: SingleValue<StatusOption>) => {
+          if (option) dispatch(setStatus(option.value));
+        }}
+        options={statusOptions}
+        filterOption={(option) => availableStatuses.includes(option.value as ManifestStatus)}
+        components={{ IndicatorSeparator: () => null, DropdownIndicator: () => null }}
+      />
     </HtForm.Group>
   );
 }

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
@@ -42,6 +42,10 @@ export function ManifestStatusField({ readOnly, isDraft }: ManifestStatusFieldPr
         profile: profile,
       })
     : [];
+  // console.log('availableStatuses', availableStatuses);
+  // console.log('profile', profile);
+  // console.log('statusOptions', statusOptions);
+  // console.log('manifest values', manifestForm.getValues());
 
   return (
     <HtForm.Group>
@@ -66,7 +70,14 @@ export function ManifestStatusField({ readOnly, isDraft }: ManifestStatusFieldPr
           if (option) setStatus(option.value);
         }}
         options={statusOptions}
-        filterOption={(option) => availableStatuses.includes(option.value as ManifestStatus)}
+        filterOption={(option) =>
+          // Hide options that are managed by EPA
+          availableStatuses.includes(option.value as ManifestStatus) || option.value === 'Scheduled'
+        }
+        isOptionDisabled={(option) =>
+          // Disable the 'Scheduled' option if it's not available
+          option.value === 'Scheduled' && !availableStatuses.includes('Scheduled')
+        }
         components={{ IndicatorSeparator: () => null, DropdownIndicator: () => null }}
       />
     </HtForm.Group>

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusField.tsx
@@ -1,0 +1,53 @@
+import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
+import { HtForm, InfoIconTooltip } from 'components/UI';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+interface ManifestStatusProps {
+  readOnly?: boolean;
+  isDraft?: boolean;
+  setManifestStatus: (status: ManifestStatus | undefined) => void;
+}
+
+export function ManifestStatusField({ readOnly, isDraft, setManifestStatus }: ManifestStatusProps) {
+  const manifestForm = useFormContext<Manifest>();
+  return (
+    <HtForm.Group>
+      <HtForm.Label htmlFor="status" className="mb-0">
+        {'Status '}
+        {!isDraft && (
+          <InfoIconTooltip message={'Once set to scheduled, this field is managed by EPA'} />
+        )}
+      </HtForm.Label>
+      <HtForm.Select
+        id="status"
+        disabled={readOnly || !isDraft}
+        aria-label="manifestStatus"
+        {...manifestForm.register('status')}
+        onChange={(event) => setManifestStatus(event.target.value as ManifestStatus | undefined)}
+      >
+        <option value="NotAssigned">Draft</option>
+        <option value="Pending">Pending</option>
+        <option value="Scheduled">Scheduled</option>
+        <option hidden value="InTransit">
+          In Transit
+        </option>
+        <option hidden value="ReadyForSignature">
+          Ready for TSDF Signature
+        </option>
+        <option hidden value="Signed">
+          Signed
+        </option>
+        <option hidden value="Corrected">
+          Corrected
+        </option>
+        <option hidden value="UnderCorrection">
+          Under Correction
+        </option>
+        <option hidden value="MtnValidationFailed">
+          MTN Validation Failed
+        </option>
+      </HtForm.Select>
+    </HtForm.Group>
+  );
+}

--- a/client/src/components/Manifest/ManifestForm.spec.tsx
+++ b/client/src/components/Manifest/ManifestForm.spec.tsx
@@ -4,11 +4,14 @@ import userEvent from '@testing-library/user-event';
 import { ManifestForm } from 'components/Manifest';
 import React from 'react';
 import { cleanup, renderWithProviders } from 'test-utils';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { setupServer } from 'msw/node';
+import { userApiMocks, wasteApiMocks } from 'test-utils/mock';
 
-afterEach(() => {
-  cleanup();
-});
+const server = setupServer(...userApiMocks, ...wasteApiMocks);
+afterEach(() => cleanup());
+beforeAll(() => server.listen());
+afterAll(() => server.close());
 
 describe('ManifestForm', () => {
   test('renders a Draft manifest', () => {

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -31,7 +31,7 @@ import { Manifest, manifestSchema, SiteType } from './manifestSchema';
 import { QuickerSignData, QuickerSignModal, QuickSignBtn } from './QuickerSign';
 import { Transporter, TransporterTable } from './Transporter';
 import { EditWasteModal, WasteLineTable } from './WasteLine';
-import { setStatus } from 'store/manifestSlice/manifest.slice';
+import { useManifestStatus } from 'hooks/manifest';
 
 const defaultValues: Manifest = {
   transporters: [],
@@ -100,11 +100,7 @@ export function ManifestForm({
       ...manifestData,
     };
   }
-
-  // Redux manifest slice
-  useEffect(() => {
-    dispatch(setStatus(values.status));
-  }, [dispatch, values]);
+  useManifestStatus(values.status);
 
   // State related to inter-system communications with EPA's RCRAInfo system
   const [showSpinner, setShowSpinner] = useState<boolean>(false);

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -6,12 +6,13 @@ import { ManifestEditBtn } from 'components/Manifest/Actions/ManifestEditBtn';
 import { ManifestFABs } from 'components/Manifest/Actions/ManifestFABs';
 import { ManifestSaveBtn } from 'components/Manifest/Actions/ManifestSaveBtn';
 import { AdditionalInfoForm } from 'components/Manifest/AdditionalInfo';
+import { GeneralInfoForm } from 'components/Manifest/GeneralInfo/GeneralInfoForm';
 import { UpdateRcra } from 'components/Manifest/UpdateRcra/UpdateRcra';
 import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
 import { RcraSiteDetails } from 'components/RcraSite';
-import { HtButton, HtCard, HtForm, InfoIconTooltip } from 'components/UI';
+import { HtButton, HtCard, HtForm } from 'components/UI';
 import React, { createContext, useEffect, useMemo, useState } from 'react';
-import { Alert, Button, Col, Container, Form, Row, Stack } from 'react-bootstrap';
+import { Alert, Button, Col, Container, Row, Stack } from 'react-bootstrap';
 import { FormProvider, SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -295,188 +296,12 @@ export function ManifestForm({
             <Stack direction="vertical" gap={3} className="px-0 px-sm-3 px-md-5">
               <HtCard id="general-form-card" title="General Info">
                 <HtCard.Body>
-                  <Row>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="manifestTrackingNumber">MTN</HtForm.Label>
-                        <Form.Control
-                          id="manifestTrackingNumber"
-                          plaintext
-                          readOnly
-                          type="text"
-                          placeholder={
-                            !manifestData?.manifestTrackingNumber
-                              ? 'Draft Manifest'
-                              : manifestData?.manifestTrackingNumber
-                          }
-                          {...manifestForm.register('manifestTrackingNumber')}
-                          className={errors.manifestTrackingNumber && 'is-invalid'}
-                        />
-                        <div className="invalid-feedback">
-                          {errors.manifestTrackingNumber?.message}
-                        </div>
-                      </HtForm.Group>
-                    </Col>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="status" className="mb-0">
-                          {'Status '}
-                          {!isDraft && (
-                            <InfoIconTooltip
-                              message={'Once set to scheduled, this field is managed by EPA'}
-                            />
-                          )}
-                        </HtForm.Label>
-                        <HtForm.Select
-                          id="status"
-                          disabled={readOnly || !isDraft}
-                          aria-label="manifestStatus"
-                          {...manifestForm.register('status')}
-                          onChange={(event) =>
-                            setManifestStatus(event.target.value as ManifestStatus | undefined)
-                          }
-                        >
-                          <option value="NotAssigned">Draft</option>
-                          <option value="Pending">Pending</option>
-                          <option value="Scheduled">Scheduled</option>
-                          <option hidden value="InTransit">
-                            In Transit
-                          </option>
-                          <option hidden value="ReadyForSignature">
-                            Ready for TSDF Signature
-                          </option>
-                          <option hidden value="Signed">
-                            Signed
-                          </option>
-                          <option hidden value="Corrected">
-                            Corrected
-                          </option>
-                          <option hidden value="UnderCorrection">
-                            Under Correction
-                          </option>
-                          <option hidden value="MtnValidationFailed">
-                            MTN Validation Failed
-                          </option>
-                        </HtForm.Select>
-                      </HtForm.Group>
-                    </Col>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="submissionType" className="mb-0">
-                          Type
-                        </HtForm.Label>
-                        <HtForm.Select
-                          id="submissionType"
-                          disabled={readOnly || !isDraft}
-                          aria-label="submissionType"
-                          {...manifestForm.register('submissionType')}
-                        >
-                          <option value="FullElectronic">Electronic</option>
-                          <option value="Hybrid">Hybrid</option>
-                          <option hidden value="DataImage5Copy">
-                            Data + Image
-                          </option>
-                          <option hidden value="Image">
-                            Image Only
-                          </option>
-                        </HtForm.Select>
-                      </HtForm.Group>
-                    </Col>
-                  </Row>
-                  <Row>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="createdDate">
-                          {'Created Date '}
-                          <InfoIconTooltip message={'This field is managed by EPA'} />
-                        </HtForm.Label>
-                        <Form.Control
-                          id="createdDate"
-                          aria-label={'created date'}
-                          plaintext
-                          disabled
-                          type="date"
-                          value={manifestData?.createdDate?.slice(0, 10)}
-                          {...manifestForm.register('createdDate')}
-                          className={errors.createdDate && 'is-invalid'}
-                        />
-                        <div className="invalid-feedback">{errors.createdDate?.message}</div>
-                      </HtForm.Group>
-                    </Col>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="updatedDate">
-                          {'Last Update Date '}
-                          <InfoIconTooltip message={'This field is managed by EPA'} />
-                        </HtForm.Label>
-                        <Form.Control
-                          id="updatedDate"
-                          plaintext
-                          disabled
-                          type="date"
-                          value={manifestData?.updatedDate?.slice(0, 10)}
-                          {...manifestForm.register('updatedDate')}
-                          className={errors.updatedDate && 'is-invalid'}
-                        />
-                        <div className="invalid-feedback">{errors.updatedDate?.message}</div>
-                      </HtForm.Group>
-                    </Col>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="shippedDate">
-                          {'Shipped Date '}
-                          <InfoIconTooltip message={'This field is managed by EPA'} />
-                        </HtForm.Label>
-                        <Form.Control
-                          id="shippedDate"
-                          disabled
-                          plaintext
-                          type="date"
-                          value={manifestData?.shippedDate?.slice(0, 10)}
-                          {...manifestForm.register('shippedDate')}
-                          className={errors.shippedDate && 'is-invalid'}
-                        />
-                        <div className="invalid-feedback">
-                          {errors.shippedDate?.message?.toString()}
-                        </div>
-                      </HtForm.Group>
-                    </Col>
-                  </Row>
-                  <Row>
-                    <Col>
-                      <HtForm.Check
-                        type="checkbox"
-                        id="import"
-                        disabled={readOnly}
-                        label="Imported Waste"
-                        {...manifestForm.register('import')}
-                        className={errors.import && 'is-invalid'}
-                      />
-                      <div className="invalid-feedback">{errors.import?.message}</div>
-                      <HtForm.Check
-                        type="checkbox"
-                        id="rejection"
-                        disabled={readOnly}
-                        label="Rejected Waste"
-                        {...manifestForm.register('rejection')}
-                        className={errors.rejection && 'is-invalid'}
-                      />
-                      <div className="invalid-feedback">{errors.rejection?.message}</div>
-                    </Col>
-                    <Col>
-                      <HtForm.Group>
-                        <HtForm.Label htmlFor="potentialShipDate">Potential Ship Date</HtForm.Label>
-                        <Form.Control
-                          id="potentialShipDate"
-                          disabled={readOnly}
-                          type="date"
-                          {...manifestForm.register('potentialShipDate')}
-                          className={errors.potentialShipDate && 'is-invalid'}
-                        />
-                        <div className="invalid-feedback">{errors.potentialShipDate?.message}</div>
-                      </HtForm.Group>
-                    </Col>
-                  </Row>
+                  <GeneralInfoForm
+                    readOnly={readOnly}
+                    manifestData={manifestData}
+                    setManifestStatus={setManifestStatus}
+                    isDraft={isDraft}
+                  />
                 </HtCard.Body>
               </HtCard>
               <HtCard id="generator-form-card" title="Generator">

--- a/client/src/components/Manifest/ManifestForm.tsx
+++ b/client/src/components/Manifest/ManifestForm.tsx
@@ -293,7 +293,7 @@ export function ManifestForm({
                 )}
               </h1>
             </div>
-            <Stack direction="vertical" gap={3} className="px-0 px-sm-3 px-md-5">
+            <Stack direction="vertical" gap={3} className="px-0 px-md-5">
               <HtCard id="general-form-card" title="General Info">
                 <HtCard.Body>
                   <GeneralInfoForm

--- a/client/src/components/Manifest/QuickerSign/SignBtn/QuickSignBtn.spec.tsx
+++ b/client/src/components/Manifest/QuickerSign/SignBtn/QuickSignBtn.spec.tsx
@@ -22,14 +22,9 @@ const mockProfile: HaztrakProfileResponse = {
 };
 
 const server = setupServer(...userApiMocks);
-afterEach(() => {
-  cleanup();
-});
+afterEach(() => cleanup());
 beforeAll(() => server.listen());
 afterAll(() => server.close()); // Disable API mocking after the tests are done.
-afterEach(() => {
-  cleanup();
-});
 
 function TestComponent({
   siteType,

--- a/client/src/components/Manifest/Transporter/TransporterTable.spec.tsx
+++ b/client/src/components/Manifest/Transporter/TransporterTable.spec.tsx
@@ -2,10 +2,12 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { Transporter } from 'components/Manifest';
 import React from 'react';
-import { renderWithProviders, screen } from 'test-utils';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { createMockTransporter } from 'test-utils/fixtures';
-import { describe, expect, test } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { TransporterTable } from './index';
+import { setupServer } from 'msw/node';
+import { userApiMocks } from 'test-utils/mock';
 
 const HANDLER_ID_1 = 'siteId1';
 const HANDLER_ID_2 = 'siteId2';
@@ -22,6 +24,10 @@ const TRAN_ARRAY: Array<Transporter> = [
     ...createMockTransporter({ epaSiteId: HANDLER_ID_2, name: HANDLER_NAME_2, order: 2 }),
   },
 ];
+const server = setupServer(...userApiMocks);
+afterEach(() => cleanup());
+beforeAll(() => server.listen());
+afterAll(() => server.close());
 
 describe('TransporterTable', () => {
   test('renders an array of transporter', () => {

--- a/client/src/components/Manifest/WasteLine/DotIdSelect.tsx
+++ b/client/src/components/Manifest/WasteLine/DotIdSelect.tsx
@@ -48,7 +48,7 @@ export function DotIdSelect() {
         render={({ field }) => {
           return (
             <Select
-              id={'idNumber'}
+              id="idNumber"
               {...field}
               value={field.value ? { label: field.value, value: field.value } : null}
               options={dotIdNumbers}

--- a/client/src/components/Manifest/WasteLine/WasteLineForm.spec.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineForm.spec.tsx
@@ -1,9 +1,18 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { renderWithProviders, screen } from 'test-utils';
-import { describe, expect, test } from 'vitest';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { WasteLineForm } from './WasteLineForm';
+import { setupServer } from 'msw/node';
+import { userApiMocks, wasteApiMocks } from 'test-utils/mock';
+
+const server = setupServer(...userApiMocks, ...wasteApiMocks);
+afterEach(() => {
+  cleanup();
+});
+beforeAll(() => server.listen());
+afterAll(() => server.close());
 
 describe('WasteLineForm', () => {
   test('renders', () => {

--- a/client/src/components/Manifest/manifestSchema.ts
+++ b/client/src/components/Manifest/manifestSchema.ts
@@ -69,6 +69,11 @@ export type ManifestStatus = z.infer<typeof manifestStatusEnum>;
 /**  The Manifest Transporter type extends the Handler schema*/
 export type Transporter = z.infer<typeof transporterSchema>;
 
+const submissionTypeEnum = z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image']);
+
+/** The type of submission for a manifest*/
+export type SubmissionType = z.infer<typeof submissionTypeEnum>;
+
 /** A signer of a hazardous waste manifest*/
 export type Signer = z.infer<typeof signerSchema>;
 /** RCRAInfo electronic signature definition*/
@@ -81,7 +86,8 @@ export const manifestSchema = z
     /** The last date-time manifest was updated in the e-Manifest system, managed by EPA's systems.*/
     updatedDate: z.string().optional(),
     /** The date-time the waste shipment departed the generator. Managed by EPA's systems*/
-    shippedDate: z.string().optional(),
+    shippedDate: submissionTypeEnum.optional(),
+    submissionType: z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image']),
     import: z.boolean().optional(),
     rejection: z.boolean().optional(),
     potentialShipDate: z
@@ -101,7 +107,6 @@ export const manifestSchema = z
     transporters: z.array(transporterSchema),
     wastes: z.array(z.any()),
     designatedFacility: handlerSchema.optional(),
-    submissionType: z.enum(['FullElectronic', 'DataImage5Copy', 'Hybrid', 'Image']),
     additionalInfo: additionalInfoSchema.optional(),
   })
   .refine(

--- a/client/src/features/NewManifest/NewManifest.tsx
+++ b/client/src/features/NewManifest/NewManifest.tsx
@@ -5,7 +5,7 @@ import { SiteSelect, SiteTypeSelect } from 'components/Manifest/SiteSelect';
 import { RcraSite } from 'components/RcraSite';
 import { HtCard, HtSpinner } from 'components/UI';
 import { useTitle } from 'hooks';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Col, Container, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
@@ -23,6 +23,14 @@ export function NewManifest() {
   const { control } = useForm();
   const { siteId } = useParams();
 
+  const updateSiteSelection = (site: RcraSite) => {
+    setManifestingSite(site);
+    setManifestingSiteType(site.siteType);
+    if (site.siteType === 'Generator') {
+      setSelectedSiteType(site.siteType);
+    }
+  };
+
   const selectBySiteId = useMemo(() => {
     return createSelector(
       (res) => res.data,
@@ -39,6 +47,13 @@ export function NewManifest() {
       rcraSite: selectBySiteId(result, siteId),
     }),
   });
+
+  useEffect(() => {
+    if (rcraSite) {
+      updateSiteSelection(rcraSite);
+    }
+  }, [rcraSite]);
+
   const [manifestingSite, setManifestingSite] = useState<RcraSite | undefined>(rcraSite);
   const [selectedSiteType, setSelectedSiteType] = useState<RcraSiteType | undefined>(
     rcraSite?.siteType === 'Generator' ? rcraSite.siteType : undefined
@@ -50,11 +65,7 @@ export function NewManifest() {
   if (isLoading && siteId) return <HtSpinner center />;
 
   const handleSiteChange = (site: any) => {
-    setManifestingSite(site);
-    setManifestingSiteType(site.siteType);
-    if (site.siteType === 'Generator') {
-      setSelectedSiteType(site.siteType);
-    }
+    updateSiteSelection(site);
   };
 
   if (!selectedSiteType || !manifestingSite) {

--- a/client/src/features/SiteDetails/SiteDetails.tsx
+++ b/client/src/features/SiteDetails/SiteDetails.tsx
@@ -1,4 +1,3 @@
-import { SyncManifestBtn } from 'components/Rcrainfo';
 import { RcraSiteDetails } from 'components/RcraSite';
 import { HtCard, HtSpinner } from 'components/UI';
 import React, { ReactElement } from 'react';
@@ -26,12 +25,9 @@ export function SiteDetails(): ReactElement {
       <Container>
         <Stack className="my-3" gap={2}>
           <div className="pe-0 d-flex flex-row-reverse">
-            <Button variant="outline-success" onClick={() => navigate(`/site/${siteId}/manifest`)}>
+            <Button variant="primary" onClick={() => navigate(`/site/${siteId}/manifest`)}>
               View Manifest
             </Button>
-            <div className="me-2">
-              <SyncManifestBtn siteId={siteId ? siteId : ''} />
-            </div>
           </div>
           <HtCard title={siteId}>
             <HtCard.Body>

--- a/client/src/hooks/manifest/index.ts
+++ b/client/src/hooks/manifest/index.ts
@@ -1,0 +1,1 @@
+export { useManifestStatus } from './useManifestStatus/useManifestStatus';

--- a/client/src/hooks/manifest/useManifestStatus/useManifestStatus.spec.tsx
+++ b/client/src/hooks/manifest/useManifestStatus/useManifestStatus.spec.tsx
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import React from 'react';
+import { renderWithProviders, screen } from 'test-utils';
+import { useManifestStatus } from './useManifestStatus';
+import userEvent from '@testing-library/user-event';
+import { ManifestStatus } from 'components/Manifest/manifestSchema';
+
+const TestChildComponent = () => {
+  const [status] = useManifestStatus();
+  return (
+    <>
+      <p>child status: {status || 'undefined'}</p>
+    </>
+  );
+};
+
+const TestComponent = ({ propStatus }: { propStatus?: ManifestStatus }) => {
+  const [status, setStatus] = useManifestStatus(propStatus);
+  return (
+    <>
+      <p>status: {status || 'undefined'}</p>
+      <button onClick={() => setStatus('Pending')}>Change Status</button>
+      <TestChildComponent />
+    </>
+  );
+};
+
+afterEach(() => cleanup());
+
+describe('useManifestStatus', () => {
+  it('status is undefined by default', () => {
+    renderWithProviders(<TestComponent />);
+    expect(screen.getByText(/^status: undefined/i)).toBeInTheDocument();
+  });
+  it('reflects the state of the redux store manifest slice', () => {
+    renderWithProviders(<TestComponent />, {
+      preloadedState: {
+        manifest: {
+          status: 'InTransit',
+          readOnly: true,
+        },
+      },
+    });
+    expect(screen.getByText(/^status: InTransit/i)).toBeInTheDocument();
+    expect(screen.getByText(/^child status: InTransit/i)).toBeInTheDocument();
+  });
+  it('updates the status in the redux store', async () => {
+    renderWithProviders(<TestComponent />, {
+      preloadedState: {
+        manifest: {
+          status: 'NotAssigned',
+          readOnly: true,
+        },
+      },
+    });
+    expect(screen.getByText(/^status: NotAssigned/i)).toBeInTheDocument();
+    expect(screen.getByText(/^child status: NotAssigned/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByText(/^status: Pending/i)).toBeInTheDocument();
+    expect(screen.getByText(/^child status: Pending/i)).toBeInTheDocument();
+  });
+  it('optional accepts a value as prop and sets as default value if present', async () => {
+    const propStatus: ManifestStatus = 'Corrected';
+    renderWithProviders(<TestComponent propStatus={propStatus} />, {
+      preloadedState: {
+        manifest: {
+          status: 'Scheduled',
+          readOnly: true,
+        },
+      },
+    });
+    expect(screen.getByText(new RegExp(`^status: ${propStatus}`, 'i'))).toBeInTheDocument();
+  });
+});

--- a/client/src/hooks/manifest/useManifestStatus/useManifestStatus.tsx
+++ b/client/src/hooks/manifest/useManifestStatus/useManifestStatus.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { ManifestStatus } from 'components/Manifest/manifestSchema';
+import { useAppDispatch, useAppSelector } from 'store';
+import { selectManifestStatus, setManifestStatus } from 'store/manifestSlice/manifest.slice';
+
+/** State management for the e-Manifest status (e.g., 'NotAssigned', 'Scheduled')
+ * @example const [status, setStatus] = useManifestStatus(optionalDefault);
+ * */
+export function useManifestStatus(propStatus?: ManifestStatus) {
+  const reduxStatus = useAppSelector(selectManifestStatus);
+  const dispatch = useAppDispatch();
+
+  const defaultValue = propStatus ? propStatus : reduxStatus ? reduxStatus : undefined;
+
+  const [status, setStatus] = useState<ManifestStatus | undefined>(defaultValue);
+
+  useEffect(() => {
+    dispatch(setManifestStatus(status));
+  }, [status]);
+
+  useEffect(() => {
+    setStatus(reduxStatus);
+  }, [reduxStatus]);
+
+  /** Set the manifest status */
+  const handleStatusChange = (newStatus: ManifestStatus | undefined) => {
+    setStatus(newStatus);
+  };
+
+  return [status, handleStatusChange] as const;
+}

--- a/client/src/services/manifest/manifest.ts
+++ b/client/src/services/manifest/manifest.ts
@@ -59,7 +59,11 @@ export const manifest = {
   getStatusOptions({ manifest, profile }: { manifest: Manifest; profile: ProfileSlice }) {
     let options: ManifestStatus[] = [];
     const currentStatus = manifest.status;
-    if (currentStatus === 'NotAssigned') {
+    if (
+      currentStatus === 'NotAssigned' ||
+      currentStatus === 'Pending' ||
+      currentStatus === 'Scheduled'
+    ) {
       options.push('NotAssigned', 'Pending');
     }
     if (manifest.designatedFacility && profile.sites) {

--- a/client/src/services/manifest/manifest.ts
+++ b/client/src/services/manifest/manifest.ts
@@ -1,5 +1,6 @@
 import { Manifest } from 'components/Manifest';
-import { RcraSiteType, SiteType } from 'components/Manifest/manifestSchema';
+import { ManifestStatus, RcraSiteType, SiteType } from 'components/Manifest/manifestSchema';
+import { ProfileSlice } from 'store';
 
 export const manifest = {
   /** Returns EPA ID of the next site that can sign on a manifest or undefined if not applicable. */
@@ -43,18 +44,6 @@ export const manifest = {
     }
     return undefined;
   },
-  rcraSiteTypeToSiteType(rcraSiteType: RcraSiteType | undefined): SiteType | undefined {
-    switch (rcraSiteType) {
-      case 'Generator':
-        return 'generator';
-      case 'Tsdf':
-        return 'designatedFacility';
-      case 'Transporter':
-        return 'transporter';
-      default:
-        return undefined;
-    }
-  },
   siteTypeToRcraSiteType(siteType: SiteType | undefined): RcraSiteType | undefined {
     switch (siteType) {
       case 'generator':
@@ -66,5 +55,18 @@ export const manifest = {
       default:
         return undefined;
     }
+  },
+  getStatusOptions({ manifest, profile }: { manifest: Manifest; profile: ProfileSlice }) {
+    let options: ManifestStatus[] = [];
+    const currentStatus = manifest.status;
+    if (currentStatus === 'NotAssigned') {
+      options.push('NotAssigned', 'Pending');
+    }
+    if (manifest.designatedFacility && profile.sites) {
+      if (manifest.designatedFacility.epaSiteId in profile.sites) {
+        options.push('Scheduled');
+      }
+    }
+    return options;
   },
 };

--- a/client/src/store/manifestSlice/manifest.slice.spec.tsx
+++ b/client/src/store/manifestSlice/manifest.slice.spec.tsx
@@ -1,19 +1,32 @@
+import '@testing-library/jest-dom';
 import { afterEach, describe, expect, test } from 'vitest';
-import reducer, { ManifestSlice, setStatus } from 'store/manifestSlice/manifest.slice';
+import reducer, {
+  ManifestSlice,
+  selectManifestReadOnly,
+  setStatus,
+} from 'store/manifestSlice/manifest.slice';
+import { useAppSelector } from 'store';
+import { renderWithProviders, screen } from 'test-utils';
 
 afterEach(() => {});
 
 const TestComponent = () => {
+  const readOnly = useAppSelector(selectManifestReadOnly);
   return (
     <div>
       <h1>Test</h1>
+      <p>{readOnly ? 'Read Only' : 'Not Read Only'}</p>
     </div>
   );
 };
 
 describe('Manifest slice', () => {
-  test('setStatus placeholder test', () => {
+  test('sets the manifest status', () => {
     const state: ManifestSlice = reducer(undefined, setStatus('NotAssigned'));
     expect(state.status).toBe('NotAssigned');
+  });
+  test('manifest slice is read only be default', () => {
+    renderWithProviders(<TestComponent />);
+    expect(screen.getByText(/Read Only/i)).toBeInTheDocument();
   });
 });

--- a/client/src/store/manifestSlice/manifest.slice.spec.tsx
+++ b/client/src/store/manifestSlice/manifest.slice.spec.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test } from 'vitest';
 import reducer, {
   ManifestSlice,
   selectManifestReadOnly,
-  setStatus,
+  setManifestStatus,
 } from 'store/manifestSlice/manifest.slice';
 import { useAppSelector } from 'store';
 import { renderWithProviders, screen } from 'test-utils';
@@ -22,7 +22,7 @@ const TestComponent = () => {
 
 describe('Manifest slice', () => {
   test('sets the manifest status', () => {
-    const state: ManifestSlice = reducer(undefined, setStatus('NotAssigned'));
+    const state: ManifestSlice = reducer(undefined, setManifestStatus('NotAssigned'));
     expect(state.status).toBe('NotAssigned');
   });
   test('manifest slice is read only be default', () => {

--- a/client/src/store/manifestSlice/manifest.slice.spec.tsx
+++ b/client/src/store/manifestSlice/manifest.slice.spec.tsx
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import reducer, { ManifestSlice, setStatus } from 'store/manifestSlice/manifest.slice';
+
+afterEach(() => {});
+
+const TestComponent = () => {
+  return (
+    <div>
+      <h1>Test</h1>
+    </div>
+  );
+};
+
+describe('Manifest slice', () => {
+  test('setStatus placeholder test', () => {
+    const state: ManifestSlice = reducer(undefined, setStatus('NotAssigned'));
+    expect(state.status).toBe('NotAssigned');
+  });
+});

--- a/client/src/store/manifestSlice/manifest.slice.ts
+++ b/client/src/store/manifestSlice/manifest.slice.ts
@@ -8,7 +8,7 @@ export interface ManifestSlice {
 
 const initialState: ManifestSlice = {
   readOnly: true,
-  status: 'NotAssigned',
+  status: undefined,
 };
 
 export const manifestSlice = createSlice({
@@ -19,7 +19,7 @@ export const manifestSlice = createSlice({
     selectManifestReadOnly: (state) => state.readOnly,
   },
   reducers: {
-    setStatus: (state, action: PayloadAction<ManifestStatus>) => {
+    setManifestStatus: (state, action: PayloadAction<ManifestStatus | undefined>) => {
       return {
         ...state,
         status: action.payload,
@@ -29,5 +29,5 @@ export const manifestSlice = createSlice({
 });
 
 export default manifestSlice.reducer;
-export const { setStatus } = manifestSlice.actions;
+export const { setManifestStatus } = manifestSlice.actions;
 export const { selectManifestStatus, selectManifestReadOnly } = manifestSlice.selectors;

--- a/client/src/store/manifestSlice/manifest.slice.ts
+++ b/client/src/store/manifestSlice/manifest.slice.ts
@@ -3,9 +3,11 @@ import { ManifestStatus } from 'components/Manifest/manifestSchema';
 
 export interface ManifestSlice {
   status?: ManifestStatus;
+  readOnly: boolean;
 }
 
 const initialState: ManifestSlice = {
+  readOnly: true,
   status: 'NotAssigned',
 };
 
@@ -14,6 +16,7 @@ export const manifestSlice = createSlice({
   initialState,
   selectors: {
     selectManifestStatus: (state) => state.status,
+    selectManifestReadOnly: (state) => state.readOnly,
   },
   reducers: {
     setStatus: (state, action: PayloadAction<ManifestStatus>) => {
@@ -27,4 +30,4 @@ export const manifestSlice = createSlice({
 
 export default manifestSlice.reducer;
 export const { setStatus } = manifestSlice.actions;
-export const { selectManifestStatus } = manifestSlice.selectors;
+export const { selectManifestStatus, selectManifestReadOnly } = manifestSlice.selectors;

--- a/client/src/store/manifestSlice/manifest.slice.ts
+++ b/client/src/store/manifestSlice/manifest.slice.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { ManifestStatus } from 'components/Manifest/manifestSchema';
+
+export interface ManifestSlice {
+  status?: ManifestStatus;
+}
+
+const initialState: ManifestSlice = {
+  status: 'NotAssigned',
+};
+
+export const manifestSlice = createSlice({
+  name: 'manifest',
+  initialState,
+  selectors: {
+    selectManifestStatus: (state) => state.status,
+  },
+  reducers: {
+    setStatus: (state, action: PayloadAction<ManifestStatus>) => {
+      return {
+        ...state,
+        status: action.payload,
+      };
+    },
+  },
+});
+
+export default manifestSlice.reducer;
+export const { setStatus } = manifestSlice.actions;
+export const { selectManifestStatus } = manifestSlice.selectors;

--- a/client/src/store/rootStore.ts
+++ b/client/src/store/rootStore.ts
@@ -4,11 +4,13 @@ import authReducers from 'store/authSlice/auth.slice';
 import { haztrakApi } from 'store/htApi.slice';
 import errorReducers from './errorSlice/error.slice';
 import notificationReducers from './notificationSlice/notification.slice';
+import manifestReducers from './manifestSlice/manifest.slice';
 
 const rootReducer = combineReducers({
   auth: authReducers,
   error: errorReducers,
   notifications: notificationReducers,
+  manifest: manifestReducers,
   [haztrakApi.reducerPath]: haztrakApi.reducer,
 });
 

--- a/client/src/test-utils/fixtures/mockWaste.ts
+++ b/client/src/test-utils/fixtures/mockWaste.ts
@@ -1,4 +1,4 @@
-import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
+import { Code, WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
 
 const DEFAULT_WASTELINE: WasteLine = {
   dotHazardous: false,
@@ -20,3 +20,27 @@ export function createMockWaste(overWrites?: Partial<WasteLine>): WasteLine {
     ...overWrites,
   };
 }
+
+export const mockFederalWasteCodes: Array<Code> = [
+  { code: 'D001', description: 'Ignitable' },
+  { code: 'D002', description: 'Corrosive' },
+  { code: 'P003', description: 'something something poly-propel' },
+];
+
+export const mockDotIdNumbers: Array<string> = [
+  'ID8000',
+  'NA0027',
+  'NA0124',
+  'NA0276',
+  'NA0323',
+  'NA0331',
+  'NA0337',
+  'NA0494',
+  'NA1057',
+  'NA1270',
+  'NA1325',
+  'NA1350',
+  'NA1361',
+  'NA1365',
+  'NA1556',
+];

--- a/client/src/test-utils/mock/index.ts
+++ b/client/src/test-utils/mock/index.ts
@@ -1,2 +1,3 @@
 export { userApiMocks } from './userApiMocks';
 export { htApiMocks } from './htApiMocks';
+export { wasteApiMocks } from './wasteApiMocks';

--- a/client/src/test-utils/mock/wasteApiMocks.ts
+++ b/client/src/test-utils/mock/wasteApiMocks.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw';
+import { mockDotIdNumbers, mockFederalWasteCodes } from 'test-utils/fixtures/mockWaste';
+
+/** mock Rest API*/
+const API_BASE_URL = import.meta.env.VITE_HT_API_URL;
+export const wasteApiMocks = [
+  /** GET User */
+  http.get(`${API_BASE_URL}/api/rcra/waste/code/federal`, (info) => {
+    return HttpResponse.json(mockFederalWasteCodes, { status: 200 });
+  }),
+  http.get(`${API_BASE_URL}/api/rcra/waste/dot/id`, (info) => {
+    const url = new URL(info.request.url);
+    const query = url.searchParams.get('q');
+    let filteredIds: Array<string> = [];
+    if (query) {
+      filteredIds = mockDotIdNumbers.filter((id) => id.includes(query));
+    } else {
+      filteredIds = mockDotIdNumbers;
+    }
+    return HttpResponse.json(filteredIds, { status: 200 });
+  }),
+];

--- a/client/src/test-utils/render.tsx
+++ b/client/src/test-utils/render.tsx
@@ -32,8 +32,8 @@ export function renderWithProviders(
   ui: React.ReactElement,
   {
     preloadedState = {}, // an object with partial slices of our redux state
-    useFormProps = {},
     store = setupStore(preloadedState), // Automatically create a store instance if no store was passed in
+    useFormProps = {}, // react-hook-form useForm function options
     ...renderOptions // react-testing library function options
   }: ExtendedRenderOptions = {} // default to empty object
 ) {


### PR DESCRIPTION
## Description

This PR adjust the criteria for when the `Scheduled` option is available on the manifest form. It is displayed as disabled if ther user does not have access to the TSDF listed on the manifest (or no TSDF is added). 

In addition, we've converted the manifest type to a react-select component for consistent style. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #565 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
