### PR TITLE
Manifest type option availability

### DIFF
--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
@@ -1,10 +1,10 @@
-import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestStatusField';
+import { ManifestStatusSelect } from 'components/Manifest/GeneralInfo/ManifestStatusSelect';
 import { Manifest, SubmissionType } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
 import { useFormContext } from 'react-hook-form';
-import Select from 'react-select';
+import { ManifestTypeSelect } from 'components/Manifest/GeneralInfo/ManifestTypeSelect';
 
 interface GeneralInfoFormProps {
   manifestData?: Partial<Manifest>;
@@ -45,32 +45,10 @@ export function GeneralInfoForm({ manifestData, readOnly, isDraft }: GeneralInfo
           </HtForm.Group>
         </Col>
         <Col>
-          <ManifestStatusField readOnly={readOnly} isDraft={isDraft} />
+          <ManifestStatusSelect readOnly={readOnly} isDraft={isDraft} />
         </Col>
         <Col>
-          <HtForm.Group>
-            <HtForm.Label htmlFor="submissionType" className="mb-0">
-              Type
-            </HtForm.Label>
-            <Select
-              id="submissionType"
-              isDisabled={readOnly || !isDraft}
-              aria-label="submissionType"
-              {...manifestForm.register('submissionType')}
-              options={submissionTypeOptions}
-              getOptionValue={(option) => option.value}
-              defaultValue={submissionTypeOptions[0]}
-              onChange={(option) => {
-                if (option) manifestForm.setValue('submissionType', option.value);
-              }}
-              filterOption={(option) => {
-                return (
-                  option.label.toLowerCase().includes('electronic') ||
-                  option.label.toLowerCase().includes('hybrid')
-                );
-              }}
-            />
-          </HtForm.Group>
+          <ManifestTypeSelect readOnly={readOnly} isDraft={isDraft} />
         </Col>
       </Row>
       <Row>

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.spec.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { ManifestStatusField } from 'components/Manifest/GeneralInfo/ManifestStatusField';
+import { ManifestStatusSelect } from 'components/Manifest/GeneralInfo/ManifestStatusSelect';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
@@ -26,7 +26,7 @@ const TestComponent = ({ isDraft, readOnly }: TestComponentProps) => {
   const readOnlyVal = readOnly !== undefined ? readOnly : false;
   return (
     <>
-      <ManifestStatusField isDraft={isDraftVal} readOnly={readOnlyVal} />
+      <ManifestStatusSelect isDraft={isDraftVal} readOnly={readOnlyVal} />
     </>
   );
 };

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.tsx
@@ -30,7 +30,7 @@ interface ManifestStatusFieldProps {
 }
 
 /** uniform hazardous waste manifest status field. */
-export function ManifestStatusField({ readOnly, isDraft }: ManifestStatusFieldProps) {
+export function ManifestStatusSelect({ readOnly, isDraft }: ManifestStatusFieldProps) {
   const [status, setStatus] = useManifestStatus();
   const selectedStatus = statusOptions.filter((value) => value.value === status);
   const manifestForm = useFormContext<Manifest>();
@@ -42,10 +42,6 @@ export function ManifestStatusField({ readOnly, isDraft }: ManifestStatusFieldPr
         profile: profile,
       })
     : [];
-  // console.log('availableStatuses', availableStatuses);
-  // console.log('profile', profile);
-  // console.log('statusOptions', statusOptions);
-  // console.log('manifest values', manifestForm.getValues());
 
   return (
     <HtForm.Group>

--- a/client/src/components/Manifest/GeneralInfo/ManifestTypeField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestTypeField.spec.tsx
@@ -5,6 +5,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { setupServer } from 'msw/node';
 import { userApiMocks } from 'test-utils/mock';
 import { ManifestTypeSelect } from 'components/Manifest/GeneralInfo/ManifestTypeSelect';
+import userEvent from '@testing-library/user-event';
+import { createMockHandler } from 'test-utils/fixtures';
 
 const server = setupServer(...userApiMocks);
 afterEach(() => cleanup());
@@ -30,5 +32,34 @@ describe('Manifest Type Field', () => {
   test('renders', () => {
     renderWithProviders(<TestComponent isDraft={true} readOnly={false} />);
     expect(screen.getByLabelText(/Type/i)).toBeInTheDocument();
+  });
+  test('hybrid is default option', () => {
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />);
+    expect(screen.getByText(/Hybrid/i)).toBeInTheDocument();
+  });
+  test('Full Electronic is disabled if no generator selected', async () => {
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />);
+    await userEvent.click(screen.getByLabelText(/Type/i));
+    expect(screen.getByRole('option', { name: 'Electronic' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+  test('Full Electronic is enabled if generator can e-Sign', async () => {
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />, {
+      useFormProps: {
+        values: {
+          generator: createMockHandler({
+            canEsign: true,
+            siteType: 'Generator',
+          }),
+        },
+      },
+    });
+    await userEvent.click(screen.getByLabelText(/Type/i));
+    expect(screen.getByRole('option', { name: 'Electronic' })).toHaveAttribute(
+      'aria-disabled',
+      'false'
+    );
   });
 });

--- a/client/src/components/Manifest/GeneralInfo/ManifestTypeField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestTypeField.spec.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { setupServer } from 'msw/node';
+import { userApiMocks } from 'test-utils/mock';
+import { ManifestTypeSelect } from 'components/Manifest/GeneralInfo/ManifestTypeSelect';
+
+const server = setupServer(...userApiMocks);
+afterEach(() => cleanup());
+beforeAll(() => server.listen());
+afterAll(() => server.close()); // Disable API mocking after the tests are done.
+
+interface TestComponentProps {
+  isDraft?: boolean;
+  readOnly?: boolean;
+}
+
+const TestComponent = ({ isDraft, readOnly }: TestComponentProps) => {
+  const isDraftVal = isDraft !== undefined ? isDraft : true;
+  const readOnlyVal = readOnly !== undefined ? readOnly : false;
+  return (
+    <>
+      <ManifestTypeSelect isDraft={isDraftVal} readOnly={readOnlyVal} />
+    </>
+  );
+};
+
+describe('Manifest Type Field', () => {
+  test('renders', () => {
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />);
+    expect(screen.getByLabelText(/Type/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Manifest/GeneralInfo/ManifestTypeSelect.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestTypeSelect.tsx
@@ -5,11 +5,13 @@ import Select from 'react-select';
 import { useFormContext } from 'react-hook-form';
 
 const submissionTypeOptions: Array<{ value: SubmissionType; label: string }> = [
-  { value: 'FullElectronic', label: 'Electronic' },
   { value: 'Hybrid', label: 'Hybrid' },
+  { value: 'FullElectronic', label: 'Electronic' },
   { value: 'DataImage5Copy', label: 'Data + Image' },
   { value: 'Image', label: 'Image Only' },
 ];
+
+const DEFAULT_SUBMISSION_TYPE = submissionTypeOptions[0];
 
 /** uniform hazardous waste manifest type field. */
 export function ManifestTypeSelect({
@@ -20,6 +22,7 @@ export function ManifestTypeSelect({
   isDraft?: boolean;
 }) {
   const manifestForm = useFormContext<Manifest>();
+  const generatorCanESign = manifestForm.getValues('generator.canEsign');
   return (
     <HtForm.Group>
       <HtForm.Label htmlFor="submissionType" className="mb-0">
@@ -32,16 +35,19 @@ export function ManifestTypeSelect({
         {...manifestForm.register('submissionType')}
         options={submissionTypeOptions}
         getOptionValue={(option) => option.value}
-        defaultValue={submissionTypeOptions[0]}
+        defaultValue={DEFAULT_SUBMISSION_TYPE}
+        classNames={{
+          control: () => 'form-select py-0 rounded-3',
+        }}
+        components={{ IndicatorSeparator: () => null, DropdownIndicator: () => null }}
         onChange={(option) => {
           if (option) manifestForm.setValue('submissionType', option.value);
         }}
-        filterOption={(option) => {
-          return (
-            option.label.toLowerCase().includes('electronic') ||
-            option.label.toLowerCase().includes('hybrid')
-          );
-        }}
+        filterOption={(option) =>
+          option.label.toLowerCase().includes('electronic') ||
+          option.label.toLowerCase().includes('hybrid')
+        }
+        isOptionDisabled={(option) => option.value === 'FullElectronic' && !generatorCanESign}
       />
     </HtForm.Group>
   );

--- a/client/src/components/Manifest/GeneralInfo/ManifestTypeSelect.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestTypeSelect.tsx
@@ -1,0 +1,48 @@
+import { Manifest, SubmissionType } from 'components/Manifest/manifestSchema';
+import { HtForm } from 'components/UI';
+import React from 'react';
+import Select from 'react-select';
+import { useFormContext } from 'react-hook-form';
+
+const submissionTypeOptions: Array<{ value: SubmissionType; label: string }> = [
+  { value: 'FullElectronic', label: 'Electronic' },
+  { value: 'Hybrid', label: 'Hybrid' },
+  { value: 'DataImage5Copy', label: 'Data + Image' },
+  { value: 'Image', label: 'Image Only' },
+];
+
+/** uniform hazardous waste manifest type field. */
+export function ManifestTypeSelect({
+  readOnly,
+  isDraft,
+}: {
+  readOnly?: boolean;
+  isDraft?: boolean;
+}) {
+  const manifestForm = useFormContext<Manifest>();
+  return (
+    <HtForm.Group>
+      <HtForm.Label htmlFor="submissionType" className="mb-0">
+        Type
+      </HtForm.Label>
+      <Select
+        id="submissionType"
+        isDisabled={readOnly || !isDraft}
+        aria-label="submissionType"
+        {...manifestForm.register('submissionType')}
+        options={submissionTypeOptions}
+        getOptionValue={(option) => option.value}
+        defaultValue={submissionTypeOptions[0]}
+        onChange={(option) => {
+          if (option) manifestForm.setValue('submissionType', option.value);
+        }}
+        filterOption={(option) => {
+          return (
+            option.label.toLowerCase().includes('electronic') ||
+            option.label.toLowerCase().includes('hybrid')
+          );
+        }}
+      />
+    </HtForm.Group>
+  );
+}


### PR DESCRIPTION
## Description

This PR adjust the manifest type select input. The new component
1. has `Hybrid` type as the default
2. `FullElectronic` option is disabled if a generator has not been added to the manifest
3. `FullElectronic` option is disabled if the selected generator cannot e-Sign
4. has unit tests associated with the component. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->

closes #673 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
