### PR TITLE
Wasteline table UI updates

### DIFF
--- a/.idea/runConfigurations/Vitest_Coverage.xml
+++ b/.idea/runConfigurations/Vitest_Coverage.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Vitest Coverage" type="JavaScriptTestRunnerVitest">
+    <config value="$PROJECT_DIR$/client/vite.config.ts" />
+    <node-interpreter value="project" />
+    <vitest-package value="$PROJECT_DIR$/client/node_modules/vitest" />
+    <working-dir value="$PROJECT_DIR$/client" />
+    <vitest-options value="--coverage" />
+    <envs>
+      <env name="VITE_HT_API_URL" value="http://localhost:8000" />
+      <env name="VITE_HT_ENV" value="DEV" />
+    </envs>
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Vitest_UI.xml
+++ b/.idea/runConfigurations/Vitest_UI.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Vitest UI" type="JavaScriptTestRunnerVitest">
+    <config value="$PROJECT_DIR$/client/vite.config.ts" />
+    <node-interpreter value="project" />
+    <vitest-package value="$PROJECT_DIR$/client/node_modules/vitest" />
+    <working-dir value="$PROJECT_DIR$/client" />
+    <vitest-options value="--ui" />
+    <envs>
+      <env name="VITE_HT_API_URL" value="http://localhost:8000" />
+      <env name="VITE_HT_ENV" value="DEV" />
+    </envs>
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -44,6 +44,7 @@
         "@types/uuid": "^9.0.7",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-istanbul": "^1.1.0",
+        "@vitest/coverage-v8": "^1.1.3",
         "@vitest/ui": "^1.1.0",
         "c8": "^8.0.1",
         "esbuild": "0.19.10",
@@ -3082,6 +3083,33 @@
         "magicast": "^0.3.2",
         "picocolors": "^1.0.0",
         "test-exclude": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.1.3.tgz",
+      "integrity": "sha512-Uput7t3eIcbSTOTQBzGtS+0kah96bX+szW9qQrLeGe3UmgL2Akn8POnyC2lH7XsnREZOds9aCUTxgXf+4HX5RA==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.2",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"

--- a/client/package.json
+++ b/client/package.json
@@ -52,7 +52,7 @@
     "@types/react-dom": "^18.2.18",
     "@types/uuid": "^9.0.7",
     "@vitejs/plugin-react": "^4.2.1",
-    "@vitest/coverage-istanbul": "^1.1.0",
+    "@vitest/coverage-v8": "^1.1.3",
     "@vitest/ui": "^1.1.0",
     "c8": "^8.0.1",
     "esbuild": "0.19.10",

--- a/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
+++ b/client/src/components/Manifest/GeneralInfo/GeneralInfoForm.tsx
@@ -1,6 +1,6 @@
 import { ManifestStatusSelect } from 'components/Manifest/GeneralInfo/ManifestStatusSelect';
 import { ManifestTypeSelect } from 'components/Manifest/GeneralInfo/ManifestTypeSelect';
-import { Manifest, SubmissionType } from 'components/Manifest/manifestSchema';
+import { Manifest } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
 import { useReadOnly } from 'hooks/manifest';
 import React from 'react';
@@ -12,13 +12,6 @@ interface GeneralInfoFormProps {
   readOnly?: boolean;
   isDraft?: boolean;
 }
-
-const submissionTypeOptions: Array<{ value: SubmissionType; label: string }> = [
-  { value: 'FullElectronic', label: 'Electronic' },
-  { value: 'Hybrid', label: 'Hybrid' },
-  { value: 'DataImage5Copy', label: 'Data + Image' },
-  { value: 'Image', label: 'Image Only' },
-];
 
 export function GeneralInfoForm({ manifestData, isDraft }: GeneralInfoFormProps) {
   const [readOnly] = useReadOnly();

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.spec.tsx
@@ -1,15 +1,15 @@
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import { ManifestStatusSelect } from 'components/Manifest/GeneralInfo/ManifestStatusSelect';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
-import userEvent from '@testing-library/user-event';
-import { setupServer } from 'msw/node';
-import { userApiMocks } from 'test-utils/mock';
-import { http, HttpResponse } from 'msw';
-import { createMockProfileResponse } from 'test-utils/fixtures/mockUser';
-import { API_BASE_URL } from 'test-utils/mock/htApiMocks';
 import { createMockHandler, createMockSite } from 'test-utils/fixtures';
+import { createMockProfileResponse } from 'test-utils/fixtures/mockUser';
+import { userApiMocks } from 'test-utils/mock';
+import { API_BASE_URL } from 'test-utils/mock/htApiMocks';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 
 const server = setupServer(...userApiMocks);
 afterEach(() => cleanup());
@@ -37,6 +37,7 @@ describe('Manifest Status Field', () => {
   });
   test('is not editable if read only', () => {
     renderWithProviders(<TestComponent isDraft={true} readOnly={true} />);
+
     expect(screen.getByLabelText(/Status/i)).toBeDisabled();
   });
   test('is editable if the manifest is a draft', () => {
@@ -88,6 +89,40 @@ describe('Manifest Status Field', () => {
     expect(scheduledOption).not.toBeDisabled();
   });
   test('Scheduled status is disabled if no access to TSDF', async () => {
+    // Arrange
+    const userGeneratorSite = createMockSite({
+      handler: createMockHandler({
+        siteType: 'Generator',
+        epaSiteId: 'MOCKVAGEN001',
+      }),
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/api/user/profile`, () => {
+        return HttpResponse.json(
+          {
+            ...createMockProfileResponse({
+              sites: [
+                {
+                  site: userGeneratorSite,
+                  eManifest: 'signer',
+                },
+              ],
+            }),
+          },
+          { status: 200 }
+        );
+      })
+    );
+    renderWithProviders(<TestComponent isDraft={true} readOnly={false} />, {
+      preloadedState: { manifest: { readOnly: false } },
+      useFormProps: { values: { status: 'NotAssigned', generator: userGeneratorSite.handler } },
+    });
+    await userEvent.click(screen.getByLabelText(/Status/i));
+    const scheduledOption = screen.queryByRole('option', { name: /Scheduled/i });
+    expect(scheduledOption).toBeInTheDocument();
+    expect(scheduledOption).toHaveAttribute('aria-disabled', 'true');
+  });
+  test('is editable if draft status', async () => {
     // Arrange
     const userGeneratorSite = createMockSite({
       handler: createMockHandler({

--- a/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestStatusSelect.tsx
@@ -1,11 +1,11 @@
 import { Manifest, ManifestStatus } from 'components/Manifest/manifestSchema';
 import { HtForm, InfoIconTooltip } from 'components/UI';
+import { useManifestStatus } from 'hooks/manifest';
 import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { useGetProfileQuery } from 'store';
-import { manifest } from 'services';
 import Select, { SingleValue } from 'react-select';
-import { useManifestStatus } from 'hooks/manifest';
+import { manifest } from 'services';
+import { useGetProfileQuery } from 'store';
 
 interface StatusOption {
   value: ManifestStatus;
@@ -43,6 +43,18 @@ export function ManifestStatusSelect({ readOnly, isDraft }: ManifestStatusFieldP
       })
     : [];
 
+  // Whether the status field should be disabled
+  const isStatusDisabled = (
+    status: ManifestStatus | undefined,
+    readOnly: boolean | undefined,
+    isDraft: boolean | undefined
+  ) => {
+    if (readOnly) return true; // Read only manifests can never be edited
+    if (isDraft) return false; // Draft manifests can always be edited if not read only
+    if (status === 'NotAssigned') return false; // if editing a previously saved 'NotAssigned', allow editing
+    return true;
+  };
+
   return (
     <HtForm.Group>
       <HtForm.Label htmlFor="status" className="mb-0">
@@ -61,7 +73,7 @@ export function ManifestStatusSelect({ readOnly, isDraft }: ManifestStatusFieldP
             aria-label="status"
             value={selectedStatus}
             options={statusOptions}
-            isDisabled={readOnly || !isDraft}
+            isDisabled={isStatusDisabled(status, readOnly, isDraft)}
             data-testid="manifestStatus"
             isLoading={profileLoading || !profile}
             onChange={(option: SingleValue<StatusOption>) => {

--- a/client/src/components/Manifest/GeneralInfo/ManifestTypeField.spec.tsx
+++ b/client/src/components/Manifest/GeneralInfo/ManifestTypeField.spec.tsx
@@ -1,12 +1,12 @@
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { ManifestTypeSelect } from 'components/Manifest/GeneralInfo/ManifestTypeSelect';
+import { setupServer } from 'msw/node';
 import React from 'react';
 import { cleanup, renderWithProviders, screen } from 'test-utils';
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
-import { setupServer } from 'msw/node';
-import { userApiMocks } from 'test-utils/mock';
-import { ManifestTypeSelect } from 'components/Manifest/GeneralInfo/ManifestTypeSelect';
-import userEvent from '@testing-library/user-event';
 import { createMockHandler } from 'test-utils/fixtures';
+import { userApiMocks } from 'test-utils/mock';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
 
 const server = setupServer(...userApiMocks);
 afterEach(() => cleanup());
@@ -61,5 +61,19 @@ describe('Manifest Type Field', () => {
       'aria-disabled',
       'false'
     );
+  });
+  test('is never editable if past draft status', async () => {
+    renderWithProviders(<TestComponent isDraft={false} readOnly={false} />, {
+      useFormProps: {
+        values: {
+          status: 'Scheduled',
+          generator: createMockHandler({
+            canEsign: true,
+            siteType: 'Generator',
+          }),
+        },
+      },
+    });
+    expect(screen.getByLabelText(/Type/i)).toBeDisabled();
   });
 });

--- a/client/src/components/Manifest/Transporter/TransporterRowActions.tsx
+++ b/client/src/components/Manifest/Transporter/TransporterRowActions.tsx
@@ -2,11 +2,13 @@ import {
   faArrowDown,
   faArrowUp,
   faEllipsisVertical,
+  faEye,
+  faEyeSlash,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { MouseEventHandler, ReactElement } from 'react';
-import { Col, Dropdown, Row } from 'react-bootstrap';
+import React, { MouseEventHandler, ReactElement, useState } from 'react';
+import { Col, Dropdown, Row, useAccordionButton } from 'react-bootstrap';
 import { UseFieldArrayRemove, UseFieldArraySwap } from 'react-hook-form';
 
 interface TranRowActionProps {
@@ -14,6 +16,7 @@ interface TranRowActionProps {
   length: number;
   removeTransporter: UseFieldArrayRemove;
   swapTransporter: UseFieldArraySwap;
+  eventKey: string;
 }
 
 interface RowDropdownItems {
@@ -34,9 +37,12 @@ export function TransporterRowActions({
   removeTransporter,
   swapTransporter,
   length,
+  eventKey,
 }: TranRowActionProps) {
   const isFirst = index === 0;
   const isLast = index + 1 === length;
+  const [open, setOpen] = useState(false);
+  const decoratedOnClick = useAccordionButton(eventKey, () => setOpen(!open));
 
   const actions: RowDropdownItems[] = [
     {
@@ -72,6 +78,15 @@ export function TransporterRowActions({
       },
       disabled: false,
       label: `remove transporter ${index}`,
+    },
+    {
+      text: open ? 'Close' : 'Details',
+      icon: <FontAwesomeIcon icon={open ? faEyeSlash : faEye} className="text-info" />,
+      onClick: (event) => {
+        decoratedOnClick(event);
+      },
+      disabled: false,
+      label: `View transporter ${index} details`,
     },
   ];
 

--- a/client/src/components/Manifest/Transporter/TransporterTable.tsx
+++ b/client/src/components/Manifest/Transporter/TransporterTable.tsx
@@ -53,15 +53,13 @@ function TransporterTable({ transporters, arrayFieldMethods, setupSign }: Transp
       <Accordion ref={parent}>
         {transporters.map((transporter, index) => {
           return (
-            <Card key={transporter.epaSiteId} className="py-2 px-4 my-2">
-              <Row className="d-flex justify-content-between">
-                <Col xs={9} className="d-flex align-items-center">
-                  <div>
-                    <h5 className="d-inline border-3 me-3">{transporter.order} </h5>
-                    <span className="text-nowrap overflow-scroll">{transporter.name}</span>
-                  </div>
+            <Card key={transporter.epaSiteId} className="py-2 ps-4 pe-2 my-2">
+              <Row className="d-flex justify-content-around">
+                <Col xs={8} className="d-flex align-items-center">
+                  <h5 className="mb-0 me-3">{transporter.order} </h5>
+                  <span className="overflow-scroll">{transporter.name}</span>
                 </Col>
-                <Col xs={1}>
+                <Col xs={2}>
                   {readOnly ? (
                     <QuickSignBtn
                       siteType={'Transporter'}
@@ -76,18 +74,18 @@ function TransporterTable({ transporters, arrayFieldMethods, setupSign }: Transp
                     <></>
                   )}
                 </Col>
-                <Col xs={1}>
-                  {readOnly || (
+                <Col xs={2} className="d-flex justify-content-end align-items-center">
+                  {readOnly ? (
+                    <CustomToggle eventKey={transporter.epaSiteId}></CustomToggle>
+                  ) : (
                     <TransporterRowActions
                       removeTransporter={arrayFieldMethods.remove}
                       swapTransporter={arrayFieldMethods.swap}
                       index={index}
                       length={transporters?.length}
+                      eventKey={transporter.epaSiteId}
                     />
                   )}
-                </Col>
-                <Col xs={1}>
-                  <CustomToggle eventKey={transporter.epaSiteId}></CustomToggle>
                 </Col>
               </Row>
               <Accordion.Collapse eventKey={transporter.epaSiteId}>

--- a/client/src/components/Manifest/WasteLine/QuantityForm.spec.tsx
+++ b/client/src/components/Manifest/WasteLine/QuantityForm.spec.tsx
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+import { QuantityForm } from 'components/Manifest/WasteLine/QuantityForm';
+import React from 'react';
+import { cleanup, renderWithProviders, screen } from 'test-utils';
+import { afterEach, describe, expect, test } from 'vitest';
+
+afterEach(() => cleanup());
+
+describe('QuantityForm', () => {
+  test('renders', () => {
+    renderWithProviders(<QuantityForm />);
+    expect(screen.getByText(/Container/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Manifest/WasteLine/QuantityForm.tsx
+++ b/client/src/components/Manifest/WasteLine/QuantityForm.tsx
@@ -1,12 +1,16 @@
 import { ErrorMessage } from '@hookform/error-message';
-import { ContainerType, WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
+import {
+  ContainerType,
+  QuantityUOM,
+  WasteLine,
+} from 'components/Manifest/WasteLine/wasteLineSchema';
 import { HtForm } from 'components/UI';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
 import { Controller, useFormContext } from 'react-hook-form';
 import Select from 'react-select';
 
-const unitsOfMeasurements = [
+const unitsOfMeasurements: Array<QuantityUOM> = [
   { code: 'P', description: 'Pounds' },
   { code: 'T', description: 'Tons (2000 Pounds)' },
   { code: 'K', description: 'Kilograms' },
@@ -45,8 +49,11 @@ export function QuantityForm() {
       <Row className="mb-2" xs={1} sm={2}>
         <Col sm={3}>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0">Count</HtForm.Label>
+            <HtForm.Label className="mb-0" htmlFor="count">
+              Count
+            </HtForm.Label>
             <Form.Control
+              id="count"
               type="number"
               min={1}
               {...register(`quantity.containerNumber`, { min: 0, valueAsNumber: true })}
@@ -93,8 +100,11 @@ export function QuantityForm() {
       <Row xs={1} sm={2}>
         <Col sm={3}>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0">Quantity</HtForm.Label>
+            <HtForm.Label className="mb-0" htmlFor="quantity">
+              Quantity
+            </HtForm.Label>
             <Form.Control
+              id="quantity"
               type="number"
               min={1}
               {...register(`quantity.quantity`, {
@@ -118,12 +128,8 @@ export function QuantityForm() {
                   <Select
                     id="quantityUnitOfMeasurement"
                     {...field}
-                    // ToDo: WasteLine type expects a string enum literal as its possible values.
-                    // ToDo: Fix these minor typescript errors
-                    // @ts-ignore
                     options={unitsOfMeasurements}
-                    // @ts-ignore
-                    getOptionLabel={(option) => option.description}
+                    getOptionLabel={(option) => option.description ?? option.code}
                     getOptionValue={(option) => option.code}
                     openMenuOnFocus={false}
                     classNames={{

--- a/client/src/components/Manifest/WasteLine/QuantityForm.tsx
+++ b/client/src/components/Manifest/WasteLine/QuantityForm.tsx
@@ -42,10 +42,10 @@ export function QuantityForm() {
 
   return (
     <>
-      <Row className="mb-2">
-        <Col xs={3}>
+      <Row className="mb-2" xs={1} sm={2}>
+        <Col sm={3}>
           <HtForm.Group className="mb-2">
-            <HtForm.Label className="mb-0">Number</HtForm.Label>
+            <HtForm.Label className="mb-0">Count</HtForm.Label>
             <Form.Control
               type="number"
               min={1}
@@ -55,7 +55,7 @@ export function QuantityForm() {
             <div className="invalid-feedback">{errors.quantity?.containerNumber?.message}</div>
           </HtForm.Group>
         </Col>
-        <Col>
+        <Col sm={9}>
           <HtForm.Group className="mb-2">
             <HtForm.Label className="mb-0" htmlFor="quantityContainerType">
               Container Type
@@ -90,8 +90,8 @@ export function QuantityForm() {
           </HtForm.Group>
         </Col>
       </Row>
-      <Row>
-        <Col xs={3}>
+      <Row xs={1} sm={2}>
+        <Col sm={3}>
           <HtForm.Group className="mb-2">
             <HtForm.Label className="mb-0">Quantity</HtForm.Label>
             <Form.Control
@@ -105,7 +105,7 @@ export function QuantityForm() {
             <div className="invalid-feedback">{errors.quantity?.quantity?.message}</div>
           </HtForm.Group>
         </Col>
-        <Col>
+        <Col sm={9}>
           <HtForm.Group className="mb-2">
             <HtForm.Label className="mb-0" htmlFor="quantityUnitOfMeasurement">
               Units

--- a/client/src/components/Manifest/WasteLine/QuantityForm.tsx
+++ b/client/src/components/Manifest/WasteLine/QuantityForm.tsx
@@ -1,5 +1,5 @@
 import { ErrorMessage } from '@hookform/error-message';
-import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
+import { ContainerType, WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
 import { HtForm } from 'components/UI';
 import React from 'react';
 import { Col, Form, Row } from 'react-bootstrap';
@@ -17,7 +17,7 @@ const unitsOfMeasurements = [
   { code: 'N', description: 'Cubic Meters' },
 ];
 
-const containerTypes = [
+const containerTypes: Array<ContainerType> = [
   { code: 'BA', description: 'Burlap, cloth, paper, or plastic bags' },
   { code: 'DT', description: 'Dump truck' },
   { code: 'CF', description: 'Fiber or plastic boxes, cartons, cases' },
@@ -67,21 +67,17 @@ export function QuantityForm() {
                 return (
                   <Select
                     id="quantityContainerType"
+                    {...field}
+                    options={containerTypes}
+                    getOptionLabel={(option) => option.description ?? option.code}
+                    getOptionValue={(option) => option.code}
+                    openMenuOnFocus={false}
                     classNames={{
                       control: () =>
                         `form-control p-0 rounded-2 ${
                           errors.quantity?.containerType && 'border-danger'
                         }`,
                     }}
-                    {...field}
-                    // ToDo: WasteLine type expects a string enum literal as its possible values.
-                    // ToDo: Fix these minor typescript errors
-                    // @ts-ignore
-                    options={containerTypes}
-                    // @ts-ignore
-                    getOptionLabel={(option) => option.description}
-                    getOptionValue={(option) => option.code}
-                    openMenuOnFocus={false}
                   />
                 );
               }}

--- a/client/src/components/Manifest/WasteLine/WasteLineForm.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineForm.tsx
@@ -6,7 +6,7 @@ import { DotIdSelect } from 'components/Manifest/WasteLine/DotIdSelect';
 import { HazardousWasteForm } from 'components/Manifest/WasteLine/HazardousWasteForm';
 import { WasteLine, wasteLineSchema } from 'components/Manifest/WasteLine/wasteLineSchema';
 import { HtCard, HtForm } from 'components/UI';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { Button, Col, Container, Form, Row, Stack } from 'react-bootstrap';
 import { Controller, FormProvider, UseFieldArrayReturn, useForm } from 'react-hook-form';
 import { QuantityForm } from './QuantityForm';
@@ -24,11 +24,11 @@ interface WasteLineFormProps {
  * @constructor
  */
 export function WasteLineForm({ handleClose, wasteForm, waste, lineNumber }: WasteLineFormProps) {
-  const [dotHazardous, setDotHazardous] = React.useState<boolean>(
+  const [dotHazardous, setDotHazardous] = useState<boolean>(
     waste?.dotHazardous === undefined ? true : waste.dotHazardous
   );
   const { editWasteLineIndex } = useContext<ManifestContextType>(ManifestContext);
-  const [epaWaste, setEpaWaste] = React.useState<boolean>(
+  const [epaWaste, setEpaWaste] = useState<boolean>(
     waste?.epaWaste === undefined ? true : waste.epaWaste
   );
 

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -66,18 +66,18 @@ export function WasteLineTable({ wastes, toggleWLModal, wasteForm }: WasteLineTa
           const description = waste.wasteDescription ?? waste.dotInformation?.printedDotInformation;
 
           return (
-            <Card key={waste.lineNumber} className="py-2 px-4 my-2">
+            <Card key={waste.lineNumber} className="py-2 ps-4 pe-2 my-2">
               <Row className="d-flex justify-content-around">
-                <Col xs={9}>
-                  <div>
-                    <h5 className="d-inline border-3 me-3">{waste.lineNumber} </h5>
-                    <span className="overflow-scroll">
-                      {waste.quantity.containerNumber} {waste.quantity.containerType.description}
-                    </span>
-                  </div>
+                <Col xs={10} className="d-flex align-items-center">
+                  <h5 className="me-3 mb-0">{waste.lineNumber} </h5>
+                  <span className="overflow-scroll">
+                    {waste.quantity.containerNumber} {waste.quantity.containerType.description}
+                  </span>
                 </Col>
-                <Col className="d-flex" xs={3}>
-                  {readOnly || (
+                <Col className="d-flex justify-content-end align-items-center" xs={2}>
+                  {readOnly ? (
+                    <CustomToggle eventKey={waste.lineNumber.toString()}></CustomToggle>
+                  ) : (
                     <WasteRowActions
                       wasteForm={wasteForm}
                       setEditWasteLine={() => setEditWasteLineIndex(index)}
@@ -85,7 +85,6 @@ export function WasteLineTable({ wastes, toggleWLModal, wasteForm }: WasteLineTa
                       index={index}
                     />
                   )}
-                  <CustomToggle eventKey={waste.lineNumber.toString()}></CustomToggle>
                 </Col>
               </Row>
               <Accordion.Collapse eventKey={waste.lineNumber.toString()}>

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -83,6 +83,7 @@ export function WasteLineTable({ wastes, toggleWLModal, wasteForm }: WasteLineTa
                       setEditWasteLine={() => setEditWasteLineIndex(index)}
                       toggleWLModal={toggleWLModal}
                       index={index}
+                      eventKey={waste.lineNumber.toString()}
                     />
                   )}
                 </Col>

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Manifest } from 'components/Manifest';
 import { ManifestContext, ManifestContextType } from 'components/Manifest/ManifestForm';
 import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
+import { WasteRowActions } from 'components/Manifest/WasteLine/WasteLineTable/WasteRowActions';
 import { useReadOnly } from 'hooks/manifest';
 import React, { useContext, useState } from 'react';
 import { Accordion, Button, Card, Col, Row, useAccordionButton } from 'react-bootstrap';
@@ -75,15 +76,15 @@ export function WasteLineTable({ wastes, toggleWLModal, wasteForm }: WasteLineTa
                     </span>
                   </div>
                 </Col>
-                <Col xs={1}>
-                  {/*{readOnly || (*/}
-                  {/*  <TransporterRowActions*/}
-                  {/*    removeTransporter={arrayFieldMethods.remove}*/}
-                  {/*    swapTransporter={arrayFieldMethods.swap}*/}
-                  {/*    index={index}*/}
-                  {/*    length={transporters?.length}*/}
-                  {/*  />*/}
-                  {/*)}*/}
+                <Col className="d-flex" xs={3}>
+                  {readOnly || (
+                    <WasteRowActions
+                      wasteForm={wasteForm}
+                      setEditWasteLine={() => setEditWasteLineIndex(index)}
+                      toggleWLModal={toggleWLModal}
+                      index={index}
+                    />
+                  )}
                   <CustomToggle eventKey={waste.lineNumber.toString()}></CustomToggle>
                 </Col>
               </Row>

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteLineTable.tsx
@@ -1,10 +1,12 @@
+import { useAutoAnimate } from '@formkit/auto-animate/react';
+import { faAngleRight, faCheckCircle, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Manifest } from 'components/Manifest';
 import { ManifestContext, ManifestContextType } from 'components/Manifest/ManifestForm';
 import { WasteLine } from 'components/Manifest/WasteLine/wasteLineSchema';
-import { WasteRowActions } from 'components/Manifest/WasteLine/WasteLineTable/WasteRowActions';
 import { useReadOnly } from 'hooks/manifest';
-import React, { useContext } from 'react';
-import { Table } from 'react-bootstrap';
+import React, { useContext, useState } from 'react';
+import { Accordion, Button, Card, Col, Row, useAccordionButton } from 'react-bootstrap';
 import { UseFieldArrayReturn } from 'react-hook-form';
 
 interface WasteLineTableProps {
@@ -13,70 +15,161 @@ interface WasteLineTableProps {
   wasteForm: UseFieldArrayReturn<Manifest, 'wastes'>;
 }
 
+const WasteCodes = ({ wasteLine }: { wasteLine: WasteLine }) => {
+  return (
+    <small
+      style={{
+        display: '-webkit-box',
+        maxHeight: '60px',
+        maxWidth: '100px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        WebkitBoxOrient: 'vertical',
+        WebkitLineClamp: 2,
+      }}
+    >
+      {wasteLine.hazardousWaste?.federalWasteCodes?.map((item) => item.code).join(', ')}
+    </small>
+  );
+};
+
+const CustomToggle = ({ eventKey }: any) => {
+  const [open, setOpen] = useState(false);
+  const decoratedOnClick = useAccordionButton(eventKey, () => setOpen(!open));
+
+  return (
+    <Button
+      onClick={decoratedOnClick}
+      className="bg-transparent border-0 text-dark me-2"
+      title="more info"
+    >
+      <FontAwesomeIcon
+        icon={faAngleRight}
+        className={`sb-sidenav-collapse-arrow ${open ? 'rotate-90' : ''} `}
+      />
+    </Button>
+  );
+};
+
 export function WasteLineTable({ wastes, toggleWLModal, wasteForm }: WasteLineTableProps) {
   const { setEditWasteLineIndex } = useContext<ManifestContextType>(ManifestContext);
-  const [readonly] = useReadOnly();
+  const [parent] = useAutoAnimate();
+  const [readOnly] = useReadOnly();
   if (!wastes || wastes.length < 1) {
     return <></>;
   }
   return (
-    <Table striped responsive>
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Description</th>
-          <th>Containers</th>
-          <th>Type</th>
-          <th>Codes</th>
-          {readonly ?? <th>Edit</th>}
-        </tr>
-      </thead>
-      <tbody>
-        {wastes.map((wasteLine, index) => {
+    <>
+      <Accordion ref={parent}>
+        {wastes.map((waste, index) => {
+          const description = waste.wasteDescription ?? waste.dotInformation?.printedDotInformation;
+
           return (
-            <tr key={index}>
-              <td>{wasteLine.lineNumber}</td>
-              <td
-                style={{
-                  maxWidth: '200px',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {wasteLine.wasteDescription ?? wasteLine.dotInformation?.printedDotInformation}
-              </td>
-              <td>{wasteLine.quantity?.containerNumber}</td>
-              <td>{String(wasteLine.quantity?.containerType.code)}</td>
-              <td>
-                <small
-                  style={{
-                    display: '-webkit-box',
-                    maxHeight: '60px',
-                    maxWidth: '100px',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    WebkitBoxOrient: 'vertical',
-                    WebkitLineClamp: 2,
-                  }}
-                >
-                  {wasteLine.hazardousWaste?.federalWasteCodes?.map((item) => item.code).join(', ')}
-                </small>
-              </td>
-              {readonly ?? (
-                <td className="text-center">
-                  <WasteRowActions
-                    index={index}
-                    wasteForm={wasteForm}
-                    toggleWLModal={toggleWLModal}
-                    setEditWasteLine={setEditWasteLineIndex}
-                  />
-                </td>
-              )}
-            </tr>
+            <Card key={waste.lineNumber} className="py-2 px-4 my-2">
+              <Row className="d-flex justify-content-around">
+                <Col xs={9}>
+                  <div>
+                    <h5 className="d-inline border-3 me-3">{waste.lineNumber} </h5>
+                    <span className="overflow-scroll">
+                      {waste.quantity.containerNumber} {waste.quantity.containerType.description}
+                    </span>
+                  </div>
+                </Col>
+                <Col xs={1}>
+                  {/*{readOnly || (*/}
+                  {/*  <TransporterRowActions*/}
+                  {/*    removeTransporter={arrayFieldMethods.remove}*/}
+                  {/*    swapTransporter={arrayFieldMethods.swap}*/}
+                  {/*    index={index}*/}
+                  {/*    length={transporters?.length}*/}
+                  {/*  />*/}
+                  {/*)}*/}
+                  <CustomToggle eventKey={waste.lineNumber.toString()}></CustomToggle>
+                </Col>
+              </Row>
+              <Accordion.Collapse eventKey={waste.lineNumber.toString()}>
+                <Card.Body className="px-1">
+                  <Row xs={1}>
+                    <Col xs={12}>
+                      <span className="fw-bold">Description</span>
+                      <p>{description}</p>
+                    </Col>
+                  </Row>
+                  <Row xs={1} sm={3}>
+                    <Col>
+                      <small className="fw-bold">Federal Waste</small>
+                      <p>
+                        {waste.epaWaste ? (
+                          <FontAwesomeIcon icon={faCheckCircle} className="text-success" />
+                        ) : (
+                          <FontAwesomeIcon icon={faCircleXmark} className="text-danger" />
+                        )}
+                      </p>
+                    </Col>
+                    <Col>
+                      <small className="fw-bold">DOT Haz Material</small>
+                      <p>
+                        {waste.dotHazardous ? (
+                          <FontAwesomeIcon icon={faCheckCircle} className="text-success" />
+                        ) : (
+                          <FontAwesomeIcon icon={faCircleXmark} className="text-danger" />
+                        )}
+                      </p>
+                    </Col>
+                    <Col>
+                      <small className="fw-bold">PCB Waste</small>
+                      <p>
+                        {waste.pcb ? (
+                          <FontAwesomeIcon icon={faCheckCircle} className="text-success" />
+                        ) : (
+                          <FontAwesomeIcon icon={faCircleXmark} className="text-danger" />
+                        )}
+                      </p>
+                    </Col>
+                  </Row>
+                  <Row xs={1}>
+                    <Col>
+                      <span className="fw-bold">Waste Codes</span>
+                      <p>
+                        <WasteCodes wasteLine={waste} />
+                      </p>
+                    </Col>
+                  </Row>
+                  <Row>
+                    <Col xs={12} sm={4}>
+                      <span className="fw-bold">Quantity</span>
+                      <p>
+                        {waste.quantity.quantity} {waste.quantity.unitOfMeasurement.description}
+                      </p>
+                    </Col>
+                    <Col xs={12} sm={8}>
+                      <span className="fw-bold">Container(s)</span>
+                      <p>
+                        {waste.quantity.containerNumber} {waste.quantity.containerType.description}
+                      </p>
+                    </Col>
+                  </Row>
+                  {/*<Table responsive>*/}
+                  {/*  <thead>*/}
+                  {/*    <tr>*/}
+                  {/*      <th>Description</th>*/}
+                  {/*      <th>Federal Waste</th>*/}
+                  {/*    </tr>*/}
+                  {/*  </thead>*/}
+                  {/*  <tbody>*/}
+                  {/*    <tr>*/}
+                  {/*      <td>{description}</td>*/}
+                  {/*      <td>*/}
+                  {/*      </td>*/}
+                  {/*    </tr>*/}
+                  {/*  </tbody>*/}
+                  {/*</Table>*/}
+                </Card.Body>
+              </Accordion.Collapse>
+            </Card>
           );
         })}
-      </tbody>
-    </Table>
+      </Accordion>
+    </>
   );
 }

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteRowActions.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteRowActions.tsx
@@ -1,8 +1,14 @@
-import { faEllipsisVertical, faPen, faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  faEllipsisVertical,
+  faEye,
+  faEyeSlash,
+  faPen,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Manifest } from 'components/Manifest';
-import React, { MouseEventHandler, ReactElement } from 'react';
-import { Col, Dropdown, Row } from 'react-bootstrap';
+import React, { MouseEventHandler, ReactElement, useState } from 'react';
+import { Col, Dropdown, Row, useAccordionButton } from 'react-bootstrap';
 import { UseFieldArrayReturn } from 'react-hook-form';
 
 interface WasteRowActionProps {
@@ -10,6 +16,7 @@ interface WasteRowActionProps {
   wasteForm: UseFieldArrayReturn<Manifest, 'wastes'>;
   toggleWLModal: () => void;
   setEditWasteLine: (index: number) => void;
+  eventKey: string;
 }
 
 interface RowDropdownItems {
@@ -29,7 +36,11 @@ function WasteRowActions({
   wasteForm,
   setEditWasteLine,
   toggleWLModal,
+  eventKey,
 }: WasteRowActionProps) {
+  const [open, setOpen] = useState(false);
+  const decoratedOnClick = useAccordionButton(eventKey, () => setOpen(!open));
+
   const actions: RowDropdownItems[] = [
     {
       text: 'Remove',
@@ -49,6 +60,15 @@ function WasteRowActions({
       },
       disabled: false,
       label: `remove waste line ${index}`,
+    },
+    {
+      text: open ? 'Close' : 'Details',
+      icon: <FontAwesomeIcon icon={open ? faEyeSlash : faEye} className="text-info" />,
+      onClick: (event) => {
+        decoratedOnClick(event);
+      },
+      disabled: false,
+      label: `view waste line ${index} details`,
     },
   ];
 

--- a/client/src/components/Manifest/WasteLine/WasteLineTable/WasteRowActions.tsx
+++ b/client/src/components/Manifest/WasteLine/WasteLineTable/WasteRowActions.tsx
@@ -1,8 +1,8 @@
-import { faTools, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faEllipsisVertical, faPen, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Manifest } from 'components/Manifest';
-import React from 'react';
-import { Button } from 'react-bootstrap';
+import React, { MouseEventHandler, ReactElement } from 'react';
+import { Col, Dropdown, Row } from 'react-bootstrap';
 import { UseFieldArrayReturn } from 'react-hook-form';
 
 interface WasteRowActionProps {
@@ -10,6 +10,14 @@ interface WasteRowActionProps {
   wasteForm: UseFieldArrayReturn<Manifest, 'wastes'>;
   toggleWLModal: () => void;
   setEditWasteLine: (index: number) => void;
+}
+
+interface RowDropdownItems {
+  text: string;
+  icon: ReactElement;
+  onClick: MouseEventHandler<HTMLElement>;
+  disabled: boolean;
+  label: string;
 }
 
 /**
@@ -22,30 +30,58 @@ function WasteRowActions({
   setEditWasteLine,
   toggleWLModal,
 }: WasteRowActionProps) {
+  const actions: RowDropdownItems[] = [
+    {
+      text: 'Remove',
+      icon: <FontAwesomeIcon icon={faTrash} className="text-danger" />,
+      onClick: () => {
+        wasteForm.remove(index);
+      },
+      disabled: false,
+      label: `remove waste line ${index}`,
+    },
+    {
+      text: 'Edit',
+      icon: <FontAwesomeIcon icon={faPen} className="text-primary" />,
+      onClick: () => {
+        setEditWasteLine(index);
+        toggleWLModal();
+      },
+      disabled: false,
+      label: `remove waste line ${index}`,
+    },
+  ];
+
   return (
-    <div className="d-flex justify-content-between mx-0">
-      <Button
-        title={`remove waste row ${index + 1}`}
-        variant="outline-danger"
-        style={{ border: 'none' }}
-        onClick={() => {
-          wasteForm.remove(index);
-        }}
-      >
-        <FontAwesomeIcon icon={faTrash} />
-      </Button>
-      <Button
-        title={`edit waste row ${index + 1}`}
-        variant="outline-primary"
-        style={{ border: 'none' }}
-        onClick={() => {
-          setEditWasteLine(index);
-          toggleWLModal();
-        }}
-      >
-        <FontAwesomeIcon icon={faTools} />
-      </Button>
-    </div>
+    <>
+      <Dropdown>
+        <Dropdown.Toggle
+          title={`transporter ${index + 1} actions`}
+          className="bg-transparent border-0 text-dark no-caret justify-content-end"
+        >
+          <FontAwesomeIcon icon={faEllipsisVertical} className="pe-2 shadow-none" />
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {actions.map((action, i) => {
+            return (
+              <Dropdown.Item
+                key={i}
+                disabled={action.disabled}
+                onClick={action.onClick}
+                title={action.label}
+              >
+                <Row>
+                  <Col xs={2}>{action.icon}</Col>
+                  <Col xs={10}>
+                    <span>{action.text}</span>
+                  </Col>
+                </Row>
+              </Dropdown.Item>
+            );
+          })}
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
   );
 }
 

--- a/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
+++ b/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
@@ -21,6 +21,8 @@ export const containerTypeSchema = z.object({
   description: z.string().optional(),
 });
 
+export type ContainerType = z.infer<typeof containerTypeSchema>;
+
 export const quantityUOMSchema = z.object({
   code: z.enum(['P', 'T', 'K', 'M', 'G', 'L', 'Y', 'N']),
   description: z.string().optional(),

--- a/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
+++ b/client/src/components/Manifest/WasteLine/wasteLineSchema.ts
@@ -28,6 +28,8 @@ export const quantityUOMSchema = z.object({
   description: z.string().optional(),
 });
 
+export type QuantityUOM = z.infer<typeof quantityUOMSchema>;
+
 const quantitySchema = z.object({
   containerNumber: z.number(),
   containerType: containerTypeSchema,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     coverage: {
-      provider: 'istanbul', // or 'v8'
+      provider: 'v8', // or 'istanbul'
       reporter: ['text', 'json', 'html'],
       exclude: [
         '**/node_modules/**',
@@ -53,6 +53,10 @@ export default defineConfig({
         '**/dist/**',
         '**/coverage/**',
         '**/src/setupTests.ts',
+        '**/src/reportWebVitals.ts',
+        '**/public/**',
+        '**/*.d.ts',
+        '**/index.ts',
       ],
     },
     globals: true,


### PR DESCRIPTION
## Description

This PR updates the UI for our waste lines on a manifest. It converts the display from a table to list of collapsible cards/Accordions. We're not worried about too many waste lines as most manifest have a limited number of waste lines to begin with. The new waste line UI reflects the transporters. 

![image](https://github.com/USEPA/haztrak/assets/43794491/c6064222-6d93-4e09-9d10-ea5c430aa656)
 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->
closes #622 

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
