### PR TITLE
Auth URL fix

### DIFF
--- a/client/src/store/userSlice/user.slice.ts
+++ b/client/src/store/userSlice/user.slice.ts
@@ -89,7 +89,7 @@ export const userApi = haztrakApi.injectEndpoints({
     // Note: build.query<ReturnType, ArgType>
     login: build.mutation<LoginResponse, LoginRequest>({
       query: (data) => ({
-        url: 'login',
+        url: 'user/login',
         method: 'POST',
         data: data,
       }),


### PR DESCRIPTION
## Description

Quick fix URL used for login endpoint on our front end. 

For reference, since we reorged the django apps, we now have all user endpoints under the `user` resource. 
so `/api/login` became `/api/user/login`

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
