### PR TITLE
EmanifestSearch class

### DIFF
--- a/client/src/components/RcraProfile/RcraProfile.tsx
+++ b/client/src/components/RcraProfile/RcraProfile.tsx
@@ -33,6 +33,7 @@ export function RcraProfile({ profile }: ProfileViewProps) {
   });
 
   useEffect(() => {
+    // ToDo: invalidating tags should be done in the slice
     dispatch(userApi.util?.invalidateTags(['rcrainfoProfile']));
   }, [inProgress]);
 
@@ -48,6 +49,7 @@ export function RcraProfile({ profile }: ProfileViewProps) {
 
   /** submitting the RcrainfoProfile form (RCRAInfo API ID, Key, username, etc.)*/
   const onSubmit = (data: RcraProfileForm) => {
+    console.log('submitting form');
     setProfileLoading(!profileLoading);
     setEditable(!editable);
     updateRcrainfoProfile({ username: profile.user, data: data });
@@ -107,37 +109,21 @@ export function RcraProfile({ profile }: ProfileViewProps) {
             </Col>
           </Row>
           <Row>
-            <div className="mx-1 d-flex flex-row-reverse">
-              {!editable ? (
-                <>
-                  <Button
-                    className="mx-2"
-                    variant="outline-info"
-                    type="button"
-                    onClick={() => {
-                      setEditable(!editable);
-                    }}
-                  >
-                    Edit
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <Button className="mx-2" variant="success" type="submit">
-                    Save
-                  </Button>
-                  <Button
-                    className="mx-2"
-                    variant="danger"
-                    onClick={() => {
-                      setEditable(!editable);
-                      reset();
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </>
-              )}
+            <div className="mx-1 d-flex flex-row justify-content-end">
+              <Button
+                className="mx-2"
+                variant={editable ? 'danger' : 'primary'}
+                type="button"
+                onClick={() => {
+                  setEditable(!editable);
+                  reset();
+                }}
+              >
+                {editable ? 'Cancel' : 'Edit'}
+              </Button>
+              <Button className="mx-2" disabled={!editable} variant="success" type="submit">
+                Save
+              </Button>
             </div>
           </Row>
         </Container>

--- a/client/src/store/htApi.slice.ts
+++ b/client/src/store/htApi.slice.ts
@@ -115,7 +115,7 @@ export const haztrakApi = createApi({
       providesTags: ['code'],
     }),
     getOrgSites: build.query<Array<HaztrakSite>, string>({
-      query: (id) => ({ url: `org/${id}/site`, method: 'get' }),
+      query: (id) => ({ url: `org/${id}/sites`, method: 'get' }),
       providesTags: ['site'],
     }),
     getUserHaztrakSites: build.query<Array<HaztrakSite>, void>({

--- a/server/apps/conftest.py
+++ b/server/apps/conftest.py
@@ -272,6 +272,15 @@ def mock_responses():
         yield mock_responses
 
 
+@pytest.fixture()
+def mock_emanifest_auth_response(request, mock_responses):
+    api_id, api_key = request.param
+    mock_responses.get(
+        f"https://rcrainfopreprod.epa.gov/rcrainfo/rest/api/v1/auth/{api_id}/{api_key}",
+        body='{"token": "mocK_token", "expiration": "2021-01-01T00:00:00.000000Z"}',
+    )
+
+
 @pytest.fixture
 def mocker(mocker: pytest_mock.MockerFixture):
     """

--- a/server/apps/core/admin.py
+++ b/server/apps/core/admin.py
@@ -44,27 +44,6 @@ class RcraSitePermissionInline(admin.TabularInline):
         return False
 
 
-# @admin.register(HaztrakProfile)
-# class HaztrakProfileAdmin(admin.ModelAdmin):
-#     list_display = ["__str__", "number_of_sites", "rcrainfo_integrated_org"]
-#     search_fields = ["user__username"]
-#     inlines = [SitePermissionsInline]
-#     raw_id_fields = ["user", "rcrainfo_profile"]
-#     readonly_fields = ["rcrainfo_integrated_org"]
-#
-#     def rcrainfo_integrated_org(self, profile: HaztrakProfile) -> bool:
-#         if profile.org:
-#             return profile.rcrainfo_integrated_org
-#         return False
-#
-#     rcrainfo_integrated_org.boolean = True
-#
-#     @staticmethod
-#     def number_of_sites(profile: HaztrakProfile) -> str:
-#         # return ", ".join([str(site) for site in profile.sit])
-#         return str(profile.site_permissions.all().count())
-
-
 @admin.register(RcrainfoProfile)
 class RcraProfileAdmin(admin.ModelAdmin):
     list_display = ["__str__", "related_user", "rcra_username", "api_user"]

--- a/server/apps/core/services/rcrainfo_service.py
+++ b/server/apps/core/services/rcrainfo_service.py
@@ -94,32 +94,6 @@ class RcrainfoService(RcrainfoClient):
         sign_data = {k: v for k, v in sign_data.items() if v is not None}
         return super().sign_manifest(**sign_data)
 
-    def search_mtn(
-        self,
-        reg: bool = False,
-        site_id: Optional[str] = None,
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
-        status: Optional[str] = None,
-        date_type: str = "UpdatedDate",
-        state_code: Optional[str] = None,
-        site_type: Optional[str] = None,
-    ) -> RcrainfoResponse:
-        # map our python friendly keyword arguments to RCRAInfo expected fields
-        search_params = {
-            "stateCode": state_code,
-            "siteId": site_id,
-            "status": status,
-            "dateType": date_type,
-            "siteType": site_type,
-            "endDate": end_date,
-            "startDate": start_date,
-        }
-        # Remove arguments that are None
-        filtered_params = {k: v for k, v in search_params.items() if v is not None}
-        logger.debug(f"rcrainfo manifest search parameters {filtered_params}")
-        return super().search_mtn(**filtered_params)
-
     def __bool__(self):
         """
         This Overrides the RcrainfoClient bool

--- a/server/apps/handler/admin.py
+++ b/server/apps/handler/admin.py
@@ -56,7 +56,6 @@ class HandlerAdmin(admin.ModelAdmin):
             return obj.generator.get()
         if obj.designated_facility:
             return obj.designated_facility.get()
-        # return obj.manifest.__str__() if obj.manifest else None
 
     related_manifest.short_description = "Manifest"
 

--- a/server/apps/manifest/services/emanifest.py
+++ b/server/apps/manifest/services/emanifest.py
@@ -80,7 +80,10 @@ class EManifest:
         data["start_date"] = self._date_or_three_years_past(search_data.get("start_date", None))
         response = self.rcrainfo.search_mtn(**data)
         if response.ok:
-            return response.json()
+            print("response OK")
+            ret = response.json()
+            print(ret)
+            return ret
         return []
 
     def pull(self, tracking_numbers: List[str]) -> PullManifestsResult:

--- a/server/apps/manifest/services/emanifest_search.py
+++ b/server/apps/manifest/services/emanifest_search.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Literal, Optional, get_args
 
 EmanifestStatus = Literal[
     "Pending",
-    "scheduled",
+    "Scheduled",
     "InTransit",
     "ReadyForSignature",
-    "signed",
+    "Signed",
     "SignedComplete",
     "UnderCorrection",
     "Corrected",
@@ -30,22 +30,50 @@ class EmanifestSearch:
         self.end_date: Optional[datetime] = None
         self.correction_request_status: Optional[CorrectionRequestStatus] = None
 
+    @staticmethod
+    def __validate_literal(value, literal) -> bool:
+        return value in get_args(literal)
+
+    @staticmethod
+    def _valid_state_code(state_code) -> bool:
+        return len(state_code) == 2 and state_code.isalpha()
+
+    @classmethod
+    def _valid_status(cls, status) -> bool:
+        return cls.__validate_literal(status, EmanifestStatus)
+
+    @classmethod
+    def _valid_site_type(cls, site_type) -> bool:
+        return cls.__validate_literal(site_type, SiteType)
+
+    @classmethod
+    def _valid_date_type(cls, date_type) -> bool:
+        return cls.__validate_literal(date_type, DateType)
+
     def add_state_code(self, state: str = None):
-        self.state_code = state if state else None
+        if not self._valid_state_code(state):
+            raise ValueError("Invalid State code")
+        self.state_code = state
         return self
 
     def add_site_id(self, site_id: str = None):
-        self.site_id = site_id if site_id else None
+        self.site_id = site_id
         return self
 
     def add_status(self, status: EmanifestStatus = None):
-        self.status = status if status else None
+        if not self._valid_status(status):
+            raise ValueError("Invalid Status")
+        self.status = status
         return self
 
     def add_site_type(self, site_type: SiteType = None):
-        self.site_type = site_type if site_type else None
+        if not self._valid_site_type(site_type):
+            raise ValueError("Invalid Site Type")
+        self.site_type = site_type
         return self
 
     def add_date_type(self, date_type: DateType = None):
-        self.date_type = date_type if date_type else None
+        if not self._valid_date_type(date_type):
+            raise ValueError("Invalid Date Type")
+        self.date_type = date_type
         return self

--- a/server/apps/manifest/services/emanifest_search.py
+++ b/server/apps/manifest/services/emanifest_search.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import Literal, Optional
+
+EmanifestStatus = Literal[
+    "Pending",
+    "scheduled",
+    "InTransit",
+    "ReadyForSignature",
+    "signed",
+    "SignedComplete",
+    "UnderCorrection",
+    "Corrected",
+]
+
+SiteType = Literal["Generator", "Tsdf", "Transporter", "RejectionInfo_AlternateTsdf"]
+
+CorrectionRequestStatus = Literal["NotSent", "Sent", "IndustryResponded", "Cancelled"]
+
+DateType = Literal["CertifiedDate", "ReceivedDate", "ShippedDate", "UpdatedDate"]
+
+
+class EmanifestSearch:
+    def __init__(self):
+        self.state_code: Optional[str] = None
+        self.site_id: Optional[str] = None
+        self.status: Optional[EmanifestStatus] = None
+        self.site_type: Optional[SiteType] = None
+        self.date_type: Optional[DateType] = None
+        self.start_date: Optional[datetime] = None
+        self.end_date: Optional[datetime] = None
+        self.correction_request_status: Optional[CorrectionRequestStatus] = None
+
+    def add_state_code(self, state: str = None):
+        self.state_code = state if state else None
+        return self
+
+    def add_site_id(self, site_id: str = None):
+        self.site_id = site_id if site_id else None
+        return self
+
+    def add_status(self, status: EmanifestStatus = None):
+        self.status = status if status else None
+        return self
+
+    def add_site_type(self, site_type: SiteType = None):
+        self.site_type = site_type if site_type else None
+        return self
+
+    def add_date_type(self, date_type: DateType = None):
+        self.date_type = date_type if date_type else None
+        return self

--- a/server/apps/manifest/services/emanifest_search.py
+++ b/server/apps/manifest/services/emanifest_search.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, Optional, get_args
 
 EmanifestStatus = Literal[
@@ -38,6 +38,10 @@ class EmanifestSearch:
     def _valid_state_code(state_code) -> bool:
         return len(state_code) == 2 and state_code.isalpha()
 
+    @staticmethod
+    def _valid_site_id(site_id: str) -> bool:
+        return len(site_id) > 2 and site_id.isalnum()
+
     @classmethod
     def _emanifest_status(cls, status) -> bool:
         return cls.__validate_literal(status, EmanifestStatus)
@@ -61,6 +65,8 @@ class EmanifestSearch:
         return self
 
     def add_site_id(self, site_id: str):
+        if not self._valid_site_id(site_id):
+            raise ValueError("Invalid Site ID")
         self.site_id = site_id
         return self
 
@@ -93,5 +99,7 @@ class EmanifestSearch:
         return self
 
     def add_end_date(self, end_date: datetime = None):
+        if not end_date:
+            end_date = datetime.now().replace(tzinfo=timezone.utc)
         self.end_date = end_date
         return self

--- a/server/apps/manifest/services/emanifest_search.py
+++ b/server/apps/manifest/services/emanifest_search.py
@@ -39,41 +39,59 @@ class EmanifestSearch:
         return len(state_code) == 2 and state_code.isalpha()
 
     @classmethod
-    def _valid_status(cls, status) -> bool:
+    def _emanifest_status(cls, status) -> bool:
         return cls.__validate_literal(status, EmanifestStatus)
 
     @classmethod
-    def _valid_site_type(cls, site_type) -> bool:
+    def _emanifest_site_type(cls, site_type) -> bool:
         return cls.__validate_literal(site_type, SiteType)
 
     @classmethod
-    def _valid_date_type(cls, date_type) -> bool:
+    def _emanifest_date_type(cls, date_type) -> bool:
         return cls.__validate_literal(date_type, DateType)
 
-    def add_state_code(self, state: str = None):
+    @classmethod
+    def _emanifest_correction_request_status(cls, correction_request_status) -> bool:
+        return cls.__validate_literal(correction_request_status, CorrectionRequestStatus)
+
+    def add_state_code(self, state: str):
         if not self._valid_state_code(state):
             raise ValueError("Invalid State code")
         self.state_code = state
         return self
 
-    def add_site_id(self, site_id: str = None):
+    def add_site_id(self, site_id: str):
         self.site_id = site_id
         return self
 
-    def add_status(self, status: EmanifestStatus = None):
-        if not self._valid_status(status):
+    def add_status(self, status: EmanifestStatus):
+        if not self._emanifest_status(status):
             raise ValueError("Invalid Status")
         self.status = status
         return self
 
-    def add_site_type(self, site_type: SiteType = None):
-        if not self._valid_site_type(site_type):
+    def add_site_type(self, site_type: SiteType):
+        if not self._emanifest_site_type(site_type):
             raise ValueError("Invalid Site Type")
         self.site_type = site_type
         return self
 
-    def add_date_type(self, date_type: DateType = None):
-        if not self._valid_date_type(date_type):
+    def add_date_type(self, date_type: DateType):
+        if not self._emanifest_date_type(date_type):
             raise ValueError("Invalid Date Type")
         self.date_type = date_type
+        return self
+
+    def add_correction_request_status(self, correction_request_status: CorrectionRequestStatus):
+        if not self._emanifest_correction_request_status(correction_request_status):
+            raise ValueError("Invalid Correction Request Status")
+        self.correction_request_status = correction_request_status
+        return self
+
+    def add_start_date(self, start_date: datetime = None):
+        self.start_date = start_date
+        return self
+
+    def add_end_date(self, end_date: datetime = None):
+        self.end_date = end_date
         return self

--- a/server/apps/manifest/tasks.py
+++ b/server/apps/manifest/tasks.py
@@ -57,10 +57,10 @@ def sign_manifest(
 @shared_task(name="sync site manifests", bind=True)
 def sync_site_manifests(self, *, site_id: str, username: str):
     """asynchronous task to sync an EPA site's manifests"""
-    from apps.rcrasite.services import HaztrakSiteService
+    from apps.site.services import TrakSiteService
 
     try:
-        site_service = HaztrakSiteService(username=username)
+        site_service = TrakSiteService(username=username)
         results = site_service.sync_manifests(site_id=site_id)
         return results
     except Exception as exc:

--- a/server/apps/manifest/tests/test_search_emanifest.py
+++ b/server/apps/manifest/tests/test_search_emanifest.py
@@ -5,6 +5,7 @@ import pytest
 
 from apps.manifest.services import EManifest
 from apps.manifest.services.emanifest import SearchManifestData
+from apps.manifest.services.emanifest_search import EmanifestSearch
 
 
 class TestSearchEManifestService:
@@ -44,3 +45,25 @@ class TestSearchEManifestService:
         _, kwargs = mock_rcrainfo.search_mtn.call_args
         start_date = kwargs["start_date"]
         assert start_date is not None
+
+
+class TestEmanifestSearchClass:
+    def test_add_state_code(self):
+        search = EmanifestSearch().add_state_code("CA")
+        assert search.state_code == "CA"
+
+    def test_add_site_id(self):
+        search = EmanifestSearch().add_site_id("test")
+        assert search.site_id == "test"
+
+    def test_add_status(self):
+        search = EmanifestSearch().add_status("Pending")
+        assert search.status == "Pending"
+
+    def test_add_site_type(self):
+        search = EmanifestSearch().add_site_type("Generator")
+        assert search.site_type == "Generator"
+
+    def test_add_date_type(self):
+        search = EmanifestSearch().add_date_type("CertifiedDate")
+        assert search.date_type == "CertifiedDate"

--- a/server/apps/manifest/tests/test_search_emanifest.py
+++ b/server/apps/manifest/tests/test_search_emanifest.py
@@ -18,22 +18,8 @@ class TestSearchEManifestService:
     def mock_response(self):
         response = Mock()
         response.ok = True
-        response.json.return_value = []
+        response.json = Mock(return_value=[])
         return response
-
-    def test_mocking_internals(self, mock_rcrainfo, mock_response):
-        # Arrange
-        emanifest = EManifest(username="test", rcrainfo=mock_rcrainfo)
-        search_data: SearchManifestData = {
-            "site_id": "test",
-            "start_date": datetime.now(),
-            "end_date": datetime.now(),
-        }
-        # Act
-        result = emanifest.search(search_data)
-        # Assert
-        assert result == []
-        assert mock_rcrainfo.search_mtn.call_count == 1
 
     def test_end_date_defaults_to_now(self, mock_rcrainfo, mock_response):
         emanifest = EManifest(username="test", rcrainfo=mock_rcrainfo)

--- a/server/apps/manifest/tests/test_search_emanifest.py
+++ b/server/apps/manifest/tests/test_search_emanifest.py
@@ -75,10 +75,6 @@ class TestEmanifestSearchClass:
             search = EmanifestSearch().add_site_id("test")
             assert search.site_id == "test"
 
-        def test_site_id_defaults_to_none(self):
-            search = EmanifestSearch().add_site_id()
-            assert search.site_id is None
-
     class TestBuildSearchWithSiteType:
         def test_add_site_type(self):
             search = EmanifestSearch().add_site_type("Generator")
@@ -96,3 +92,21 @@ class TestEmanifestSearchClass:
         def test_raises_error_with_invalid_date_type(self):
             with pytest.raises(ValueError):
                 EmanifestSearch().add_date_type("InvalidDateType")
+
+    class TestBuildSearchWithDates:
+        def test_add_start_date(self):
+            search = EmanifestSearch().add_start_date(datetime.now())
+            assert search.start_date is not None
+
+        def test_add_end_date(self):
+            search = EmanifestSearch().add_end_date(datetime.now())
+            assert search.end_date is not None
+
+    class TestBuildSearchWithCorrectionRequestStatus:
+        def test_add_correction_request_status(self):
+            search = EmanifestSearch().add_correction_request_status("Sent")
+            assert search.correction_request_status == "Sent"
+
+        def test_error_raised_with_invalid_correction_request_status(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_correction_request_status("InvalidStatus")

--- a/server/apps/manifest/tests/test_search_emanifest.py
+++ b/server/apps/manifest/tests/test_search_emanifest.py
@@ -48,22 +48,51 @@ class TestSearchEManifestService:
 
 
 class TestEmanifestSearchClass:
-    def test_add_state_code(self):
-        search = EmanifestSearch().add_state_code("CA")
-        assert search.state_code == "CA"
+    class TestBuildSearchWithStateCode:
+        def test_add_state_code(self):
+            search = EmanifestSearch().add_state_code("CA")
+            assert search.state_code == "CA"
 
-    def test_add_site_id(self):
-        search = EmanifestSearch().add_site_id("test")
-        assert search.site_id == "test"
+        def test_state_code_only_accepts_two_letters(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_state_code("California")
 
-    def test_add_status(self):
-        search = EmanifestSearch().add_status("Pending")
-        assert search.status == "Pending"
+        def test_state_code_alphabetical(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_state_code("12")
 
-    def test_add_site_type(self):
-        search = EmanifestSearch().add_site_type("Generator")
-        assert search.site_type == "Generator"
+    class TestBuildSearchWithStatus:
+        def test_add_status(self):
+            search = EmanifestSearch().add_status("Pending")
+            assert search.status == "Pending"
 
-    def test_add_date_type(self):
-        search = EmanifestSearch().add_date_type("CertifiedDate")
-        assert search.date_type == "CertifiedDate"
+        def test_error_raised_with_invalid_status(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_status("InvalidStatus")
+
+    class TestBuildSearchWithSiteId:
+        def test_add_site_id(self):
+            search = EmanifestSearch().add_site_id("test")
+            assert search.site_id == "test"
+
+        def test_site_id_defaults_to_none(self):
+            search = EmanifestSearch().add_site_id()
+            assert search.site_id is None
+
+    class TestBuildSearchWithSiteType:
+        def test_add_site_type(self):
+            search = EmanifestSearch().add_site_type("Generator")
+            assert search.site_type == "Generator"
+
+        def test_error_raised_with_invalid_site_type(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_site_type("InvalidSiteType")
+
+    class TestBuildSearchWithDateType:
+        def test_add_date_type(self):
+            search = EmanifestSearch().add_date_type("CertifiedDate")
+            assert search.date_type == "CertifiedDate"
+
+        def test_raises_error_with_invalid_date_type(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_date_type("InvalidDateType")

--- a/server/apps/manifest/tests/test_search_emanifest.py
+++ b/server/apps/manifest/tests/test_search_emanifest.py
@@ -1,5 +1,5 @@
-from datetime import datetime
-from unittest.mock import Mock
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -68,12 +68,18 @@ class TestEmanifestSearchClass:
 
         def test_error_raised_with_invalid_status(self):
             with pytest.raises(ValueError):
-                EmanifestSearch().add_status("InvalidStatus")
+                EmanifestSearch().add_status("InvalidStatus")  # noqa
 
     class TestBuildSearchWithSiteId:
         def test_add_site_id(self):
             search = EmanifestSearch().add_site_id("test")
             assert search.site_id == "test"
+            search_2 = EmanifestSearch().add_site_id("test123")
+            assert search_2.site_id == "test123"
+
+        def test_site_id_is_alphanumeric(self):
+            with pytest.raises(ValueError):
+                EmanifestSearch().add_site_id("test!")
 
     class TestBuildSearchWithSiteType:
         def test_add_site_type(self):
@@ -82,7 +88,7 @@ class TestEmanifestSearchClass:
 
         def test_error_raised_with_invalid_site_type(self):
             with pytest.raises(ValueError):
-                EmanifestSearch().add_site_type("InvalidSiteType")
+                EmanifestSearch().add_site_type("InvalidSiteType")  # noqa
 
     class TestBuildSearchWithDateType:
         def test_add_date_type(self):
@@ -91,7 +97,7 @@ class TestEmanifestSearchClass:
 
         def test_raises_error_with_invalid_date_type(self):
             with pytest.raises(ValueError):
-                EmanifestSearch().add_date_type("InvalidDateType")
+                EmanifestSearch().add_date_type("InvalidDateType")  # noqa
 
     class TestBuildSearchWithDates:
         def test_add_start_date(self):
@@ -102,6 +108,13 @@ class TestEmanifestSearchClass:
             search = EmanifestSearch().add_end_date(datetime.now())
             assert search.end_date is not None
 
+        def test_add_end_date_defaults_to_now(self):
+            with patch("apps.manifest.services.emanifest_search.datetime") as mock_datetime:
+                mock_datetime.now.return_value = datetime(2021, 1, 1).replace(tzinfo=timezone.utc)
+                search = EmanifestSearch().add_end_date()
+                assert search.end_date is not None
+                assert search.end_date == datetime(2021, 1, 1).replace(tzinfo=timezone.utc)
+
     class TestBuildSearchWithCorrectionRequestStatus:
         def test_add_correction_request_status(self):
             search = EmanifestSearch().add_correction_request_status("Sent")
@@ -109,4 +122,4 @@ class TestEmanifestSearchClass:
 
         def test_error_raised_with_invalid_correction_request_status(self):
             with pytest.raises(ValueError):
-                EmanifestSearch().add_correction_request_status("InvalidStatus")
+                EmanifestSearch().add_correction_request_status("InvalidStatus")  # noqa

--- a/server/apps/manifest/tests/test_search_emanifest.py
+++ b/server/apps/manifest/tests/test_search_emanifest.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from apps.manifest.services import EManifest
+from apps.manifest.services.emanifest import SearchManifestData
+
+
+class TestSearchEManifestService:
+    @pytest.fixture()
+    def mock_rcrainfo(self):
+        rcrainfo_client = Mock()
+        rcrainfo_client.datetime_format = "%Y-%m-%d"
+        return rcrainfo_client
+
+    @pytest.fixture()
+    def mock_response(self):
+        response = Mock()
+        response.ok = True
+        response.json.return_value = []
+        return response
+
+    def test_mocking_internals(self, mock_rcrainfo, mock_response):
+        # Arrange
+        emanifest = EManifest(username="test", rcrainfo=mock_rcrainfo)
+        search_data: SearchManifestData = {
+            "site_id": "test",
+            "start_date": datetime.now(),
+            "end_date": datetime.now(),
+        }
+        # Act
+        result = emanifest.search(search_data)
+        # Assert
+        assert result == []
+        assert mock_rcrainfo.search_mtn.call_count == 1
+
+    def test_end_date_defaults_to_now(self, mock_rcrainfo, mock_response):
+        emanifest = EManifest(username="test", rcrainfo=mock_rcrainfo)
+        search_data: SearchManifestData = {
+            "site_id": "test",
+            "start_date": datetime.now(),
+        }
+        # Act
+        emanifest.search(search_data)
+        _, kwargs = mock_rcrainfo.search_mtn.call_args
+        end_date = kwargs["end_date"]
+        assert end_date is not None
+        assert end_date == datetime.now().strftime(mock_rcrainfo.datetime_format)
+
+    def test_uses_a_default_start_date(self, mock_rcrainfo, mock_response):
+        emanifest = EManifest(username="test", rcrainfo=mock_rcrainfo)
+        search_data: SearchManifestData = {
+            "site_id": "test",
+        }
+        # Act
+        emanifest.search(search_data)
+        _, kwargs = mock_rcrainfo.search_mtn.call_args
+        start_date = kwargs["start_date"]
+        assert start_date is not None

--- a/server/apps/org/admin.py
+++ b/server/apps/org/admin.py
@@ -3,11 +3,6 @@ from django.contrib import admin
 from apps.org.models import TrakOrg, TrakOrgAccess
 from apps.site.models import TrakSite
 
-# class HaztrakProfileInline(admin.TabularInline):
-#     model = HaztrakProfile
-#     extra = 0
-
-
 admin.site.register(TrakOrgAccess)
 
 

--- a/server/apps/org/admin.py
+++ b/server/apps/org/admin.py
@@ -1,11 +1,14 @@
 from django.contrib import admin
 
-from apps.org.models import TrakOrg
+from apps.org.models import TrakOrg, TrakOrgAccess
 from apps.site.models import TrakSite
 
 # class HaztrakProfileInline(admin.TabularInline):
 #     model = HaztrakProfile
 #     extra = 0
+
+
+admin.site.register(TrakOrgAccess)
 
 
 @admin.register(TrakOrg)

--- a/server/apps/profile/serializers/rcrasite_access.py
+++ b/server/apps/profile/serializers/rcrasite_access.py
@@ -87,23 +87,15 @@ class RcraPermissionField(serializers.Field):
     """Serializer for communicating with RCRAInfo, translates internal to RCRAInfo field names."""
 
     def to_representation(self, value):
-        if value:
-            # convert boolean to 'Active' or 'Inactive' when talking to RcraInfo
-            value = "Active"
-        elif not value:
-            value = "InActive"
+        value = "Active" if value else "InActive"
         # RcraInfo gives us an array of object with module and level keys
-        ret = {"module": f"{self.field_name}", "level": value}
-        return ret
+        return {"module": f"{self.field_name}", "level": value}
 
     def to_internal_value(self, data):
         try:
-            data = data["level"]
-            if data == "Active":
-                data = True
-            elif data == "InActive":
-                data = False
-            return data
+            passed_value = data["level"]
+            # if 'Active' or 'InActive' is passed, convert it to True or False
+            return {"Active": True, "InActive": False}.get(passed_value, passed_value)
         except KeyError as exc:
             raise ValidationError(f"malformed JSON: {exc}")
 

--- a/server/apps/site/services.py
+++ b/server/apps/site/services.py
@@ -56,8 +56,9 @@ class TrakSiteService:
 
     def _get_updated_mtn(self, site_id: str, last_sync_date: datetime) -> list[str]:
         logger.info(f"retrieving updated MTN for site {site_id}")
-        emanifest = EManifest(username=self.username, rcrainfo=self.rcrainfo)
-        return emanifest.search(site_id=site_id, start_date=last_sync_date)
+        return EManifest(username=self.username, rcrainfo=self.rcrainfo).search(
+            {"site_id": site_id, "start_date": last_sync_date}
+        )
 
 
 class TrakSiteServiceError(Exception):

--- a/server/apps/site/services.py
+++ b/server/apps/site/services.py
@@ -7,6 +7,7 @@ from django.db.models import QuerySet
 
 from apps.core.services import RcrainfoService, get_rcrainfo_client
 from apps.manifest.services import EManifest, PullManifestsResult, TaskResponse
+from apps.manifest.services.emanifest_search import EmanifestSearch
 from apps.manifest.tasks import sync_site_manifests
 from apps.site.models import TrakSite
 
@@ -56,8 +57,12 @@ class TrakSiteService:
 
     def _get_updated_mtn(self, site_id: str, last_sync_date: datetime) -> list[str]:
         logger.info(f"retrieving updated MTN for site {site_id}")
-        return EManifest(username=self.username, rcrainfo=self.rcrainfo).search(
-            {"site_id": site_id, "start_date": last_sync_date}
+        return (
+            EmanifestSearch(self.rcrainfo)
+            .add_site_id(site_id)
+            .add_start_date(last_sync_date)
+            .add_end_date()
+            .execute()
         )
 
 

--- a/server/haztrak/urls.py
+++ b/server/haztrak/urls.py
@@ -13,8 +13,9 @@ Including another URLconf
     1. Import the 'include()' function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 # Change the Django Admin page title
@@ -22,6 +23,7 @@ admin.site.site_header = "Haztrak Admin"
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    re_path(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path(
         "api/",
         include(


### PR DESCRIPTION
## Description
This PR adds a new `EmanifestSearch` class we use for querying the e-Manifest API for manifests (the manifest search endpoint). The e-Manifest team kind of uses this search endpoint as a swiss army blade for finding manifest data. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->

## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
