### PR TITLE
requirements_dev.txt location

### DIFF
--- a/docs/guide/src/development/local-development.md
+++ b/docs/guide/src/development/local-development.md
@@ -101,7 +101,7 @@ style guide. Most popular IDEs have a plugin to support these configs.
 - pre-commit
   - [pre-commit](https://pre-commit.com/) hooks are set to run a number of linting and formatting checks before commits on any branch is accepted.
   ```shell
-   pip install -r requirements_dev.txt
+   pip install -r server/requirements_dev.txt
    pre-commit install
   ```
 - .editorconfig


### PR DESCRIPTION
Edited shell command for installing requirements_dev.txt to point to its location within the server directory

## Description


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
