### PR TITLE
Repair TransporterSection by properly adding uuid to clientKey

### DIFF
--- a/client/src/components/Manifest/Transporter/TransporterSection.tsx
+++ b/client/src/components/Manifest/Transporter/TransporterSection.tsx
@@ -12,10 +12,6 @@ interface TransporterSectionProps {
   setupSign: () => void;
 }
 
-interface TransporterWithKey extends Transporter {
-  key: string;
-}
-
 export function TransporterSection({ setupSign }: TransporterSectionProps) {
   const [, setSearchConfigs] = useHandlerSearchConfig();
   const [readOnly] = useReadOnly();
@@ -25,7 +21,7 @@ export function TransporterSection({ setupSign }: TransporterSectionProps) {
     control: manifestForm.control,
     name: 'transporters',
   });
-  const transporters = transporterForm.fields;
+  const transporters = manifestForm.watch('transporters');
 
   transporters.forEach((transporter, index) => {
     if (!transporter.clientKey) {


### PR DESCRIPTION
## Description
[PR718](https://github.com/USEPA/haztrak/pull/718) created a break in the Manifest form that prevented the user from adding transporters to the manifest. This PR will change the methodology by which the uuid is added to each transporter in the transporter list.


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
