### PR TITLE
Chart enhancement

### DIFF
--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -265,10 +265,11 @@ body {
 
 @import '~bootstrap/scss/bootstrap';
 
-button {
+button.recharts-legend-item {
   all: unset;
+  cursor: pointer;
 }
 
-button:focus {
-  outline: revert;
+.recharts-legend-item:focus .recharts-legend-item-text {
+  border-bottom: 2px solid;
 }

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -264,3 +264,11 @@ body {
 }
 
 @import '~bootstrap/scss/bootstrap';
+
+button {
+  all: unset;
+}
+
+button:focus {
+  outline: revert;
+}

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Sector } from 'recharts';
 import { useNavigate } from 'react-router-dom';
 
@@ -160,7 +160,7 @@ const renderLegend = (props: any) => {
               key={`item-${index}`}
               onMouseEnter={() => handleMouseEnter(null, index)}
               onMouseLeave={handleMouseLeave}
-              onClick={() => handleClick(dataEntry)}
+              onClick={handleClick(dataEntry)}
               className={`recharts-legend-item legend-item-${index}`}
               style={{ display: 'inline-block', marginRight: '10px' }}
             >
@@ -193,6 +193,7 @@ const renderLegend = (props: any) => {
 
 export function ManifestStatusPieChart() {
   const [activeIndex, setActiveIndex] = useState(-1);
+  const [chartRenderComplete, setChartRenderComplete] = useState(false);
   const navigate = useNavigate();
 
   const handleMouseEnter = useCallback(
@@ -206,12 +207,20 @@ export function ManifestStatusPieChart() {
     setActiveIndex(-1);
   }, [setActiveIndex]);
 
-  const handleClick = (entry: Entry) => {
+  const renderLabel = (props: any) => {
+    if (chartRenderComplete) {
+      return renderCustomLabel({ ...props, hover: false, activeIndex: activeIndex });
+    }
+  };
+
+  const handleClick = (entry: Entry) => () => {
     navigate({
       pathname: './manifest',
       search: `?status=${entry.searchParam}`,
     });
   };
+
+  const animationDuration = chartRenderComplete ? 0 : 1000;
 
   return (
     <ResponsiveContainer minWidth={100} minHeight={300} height="10%">
@@ -224,6 +233,8 @@ export function ManifestStatusPieChart() {
           height={36}
         />
         <Pie
+          animationDuration={animationDuration}
+          onAnimationEnd={() => setChartRenderComplete(true)}
           activeIndex={activeIndex}
           activeShape={(props: any) => renderShape(props, true)}
           inactiveShape={(props: any) => renderShape(props, false)}
@@ -234,9 +245,7 @@ export function ManifestStatusPieChart() {
           fill="#8884d8"
           dataKey="value"
           labelLine={false}
-          label={(props: any) =>
-            renderCustomLabel({ ...props, hover: false, activeIndex: activeIndex })
-          }
+          label={renderLabel}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
           cursor={'pointer'}
@@ -245,7 +254,7 @@ export function ManifestStatusPieChart() {
             <Cell
               key={`cell-${index}`}
               fill={index === activeIndex ? COLORS[index].active : COLORS[index].normal}
-              onClick={() => handleClick(entry)}
+              onClick={handleClick(entry)}
             />
           ))}
         </Pie>

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -1,43 +1,248 @@
-import React from 'react';
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from 'recharts';
+import { useState, useCallback } from 'react';
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Sector } from 'recharts';
 import { useNavigate } from 'react-router-dom';
 
-const data = [
+interface Entry {
+  name: string;
+  value: number;
+  searchParam: string;
+}
+
+const data: Array<Entry> = [
   { name: 'Pending', value: 40, searchParam: 'pending' },
   { name: 'Scheduled', value: 39, searchParam: 'scheduled' },
   { name: 'In Transit', value: 33, searchParam: 'intransit' },
   { name: 'Ready for TSDF Signature', value: 21, searchParam: 'readyforsignature' },
 ];
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042'];
+const normalAlpha = '0.6';
+const activeAlpha = '1';
+
+const COLORS = [
+  { normal: `rgba(0, 136, 254, ${normalAlpha})`, active: `rgba(0, 136, 254, ${activeAlpha})` },
+  { normal: `rgba(0, 196, 159, ${normalAlpha})`, active: `rgba(0, 196, 159, ${activeAlpha})` },
+  { normal: `rgba(255, 187, 40, ${normalAlpha})`, active: `rgba(255, 187, 40, ${activeAlpha})` },
+  { normal: `rgba(255, 128, 66, ${normalAlpha})`, active: `rgba(255, 128, 66, ${activeAlpha})` },
+];
+
+const RADIAN = Math.PI / 180;
+
+const renderCustomLabel = (props: any) => {
+  const { cx, cy, midAngle, outerRadius, value, hover, activeIndex } = props;
+
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const lx = cx + (outerRadius - 30) * cos;
+  const ly = cy + (outerRadius - 30) * sin;
+  const hoverPieX = lx + 8 * cos;
+  const hoverPieY = ly + 8 * sin;
+
+  const label = (
+    <text
+      x={hover ? hoverPieX : lx}
+      y={hover ? hoverPieY : ly}
+      fill="white"
+      dominantBaseline="central"
+    >
+      {`${value}`}
+    </text>
+  );
+
+  return activeIndex < 0 ? label : null;
+};
+
+const renderOuterRing = (props: any) => {
+  const { cx, cy, midAngle, outerRadius, startAngle, endAngle, fill, payload, percent } = props;
+
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const PIE_HOVER_OFFSET_DISTANCE = 9;
+
+  const hoverPieX = cx + PIE_HOVER_OFFSET_DISTANCE * cos;
+  const hoverPieY = cy + PIE_HOVER_OFFSET_DISTANCE * sin;
+
+  const labelStartX = hoverPieX + (outerRadius + 10) * cos;
+  const labelStartY = hoverPieY + (outerRadius + 10) * sin;
+  const labelMidX = hoverPieX + (outerRadius + 30) * cos;
+  const labelMidY = hoverPieY + (outerRadius + 30) * sin;
+
+  const labelEndX = labelMidX + (cos >= 0 ? 1 : -1) * 22;
+  const labelEndY = labelMidY;
+  const textAnchor = cos >= 0 ? 'start' : 'end';
+
+  return (
+    <>
+      <Sector
+        cx={hoverPieX}
+        cy={hoverPieY}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        innerRadius={outerRadius + 6}
+        outerRadius={outerRadius + 11}
+        fill={fill}
+      />
+      {renderCustomLabel({
+        cx,
+        cy,
+        midAngle,
+        outerRadius,
+        value: payload.value,
+        hover: true,
+        activeIndex: -1,
+      })}
+      <path
+        d={`M${labelStartX},${labelStartY}L${labelMidX},${labelMidY}L${labelEndX},${labelEndY}`}
+        stroke={fill}
+        fill="none"
+      />
+      <circle cx={labelEndX} cy={labelEndY} r={2} fill={fill} stroke="none" />
+      <text
+        x={labelEndX + (cos >= 0 ? 12 : -12)}
+        y={labelEndY}
+        dy={6}
+        textAnchor={textAnchor}
+        fill="#333"
+      >{`${(percent * 100).toFixed(2)}%`}</text>
+    </>
+  );
+};
+
+const renderShape = (props: any, isActive: boolean) => {
+  const { cx, cy, midAngle, innerRadius, outerRadius, startAngle, endAngle, fill, onClick } = props;
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const offset = isActive ? 9 : 0;
+  const x = cx + offset * cos;
+  const y = cy + offset * sin;
+
+  return (
+    <g>
+      <Sector
+        cursor={'pointer'}
+        cx={x}
+        cy={y}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+        onClick={onClick}
+      />
+      {isActive && renderOuterRing(props)}
+    </g>
+  );
+};
+
+const renderLegend = (props: any) => {
+  const { payload, handleMouseEnter, handleMouseLeave } = props;
+
+  return (
+    <div
+      className="recharts-legend-wrapper"
+      style={{ position: 'absolute', width: '626px', height: '36px', left: '5px', bottom: '5px' }}
+    >
+      <ul
+        className="recharts-default-legend"
+        style={{ padding: '0px', margin: '0px', textAlign: 'center' }}
+      >
+        {payload.map((entry: any, index: number) => {
+          const activeLegend =
+            entry.color.slice(entry.color.lastIndexOf(' ') + 1, entry.color.length - 1) === '1';
+          const baseStyle = { color: entry.color, paddingBottom: '2px' };
+          const spanStyle = activeLegend
+            ? { ...baseStyle, borderBottom: `2px solid ${entry.color}` }
+            : { ...baseStyle };
+
+          return (
+            <li
+              key={`item-${index}`}
+              onMouseEnter={() => handleMouseEnter(null, index)}
+              onMouseLeave={handleMouseLeave}
+              className={`recharts-legend-item legend-item-${index}`}
+              style={{ display: 'inline-block', marginRight: '10px' }}
+            >
+              <svg
+                className="recharts-surface"
+                width="14"
+                height="14"
+                style={{ display: 'inline-block', verticalAlign: 'middle', marginRight: '4px' }}
+                viewBox="0 0 32 32"
+              >
+                <title></title>
+                <desc></desc>
+                <path
+                  stroke="none"
+                  fill={entry.color}
+                  d="M0,4h32v24h-32z"
+                  className="recharts-legend-icon"
+                ></path>
+              </svg>
+              <span className="recharts-legend-item-text" style={spanStyle}>
+                {entry.value}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
 
 export function ManifestStatusPieChart() {
+  const [activeIndex, setActiveIndex] = useState(-1);
   const navigate = useNavigate();
+
+  const handleMouseEnter = useCallback(
+    (_: any, index: number) => {
+      setActiveIndex(index);
+    },
+    [setActiveIndex]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    setActiveIndex(-1);
+  }, [setActiveIndex]);
+
+  const handleClick = (entry: Entry) => {
+    navigate({
+      pathname: './manifest',
+      search: `?status=${entry.searchParam}`,
+    });
+  };
+
   return (
-    <ResponsiveContainer minWidth={100} minHeight={300} height={'10%'}>
+    <ResponsiveContainer minWidth={100} minHeight={300} height="10%">
       <PieChart width={400} height={400}>
-        <Legend verticalAlign="bottom" height={36} />
+        <Legend
+          content={(props: any) => renderLegend({ ...props, handleMouseEnter, handleMouseLeave })}
+          verticalAlign="bottom"
+          height={36}
+        />
         <Pie
+          activeIndex={activeIndex}
+          activeShape={(props: any) => renderShape(props, true)}
+          inactiveShape={(props: any) => renderShape(props, false)}
           data={data}
           cx="50%"
           cy="50%"
-          label={true}
-          labelLine={true}
           outerRadius={80}
           fill="#8884d8"
           dataKey="value"
+          labelLine={false}
+          label={(props: any) =>
+            renderCustomLabel({ ...props, hover: false, activeIndex: activeIndex })
+          }
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          cursor={'pointer'}
         >
-          {data.map((entry, index) => {
-            return (
-              <Cell
-                key={`cell-${index}`}
-                fill={COLORS[index % COLORS.length]}
-                onClick={() => {
-                  navigate({ pathname: './manifest', search: `?status=${entry.searchParam}` });
-                }}
-              />
-            );
-          })}
+          {data.map((entry: Entry, index: number) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={index === activeIndex ? COLORS[index].active : COLORS[index].normal}
+              onClick={() => handleClick(entry)}
+            />
+          ))}
         </Pie>
       </PieChart>
     </ResponsiveContainer>

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -144,7 +144,8 @@ const renderOuterRing = (props: any): ReactElement => {
   );
 };
 
-const renderShape = (props: any): ReactElement => {
+/** Render the currently focused pie slice*/
+const renderActiveShape = (props: any): ReactElement => {
   const { cx, cy, midAngle, innerRadius, outerRadius, startAngle, endAngle, fill, onClick } = props;
   const { sin, cos } = calculateTrig(midAngle);
   const offset = 9;
@@ -234,14 +235,14 @@ export function ManifestStatusPieChart() {
 
   const handleMouseEnter = useCallback(
     (_: any, index: number) => {
-      setAnimationIsActive(false);
+      setAnimationIsActive(false); // stop animation if impatient user
       setActiveIndex(index);
     },
     [setActiveIndex]
   );
 
   const handleMouseLeave = useCallback(() => {
-    setAnimationIsActive(false);
+    setAnimationIsActive(false); // stop animation if impatient user
     setActiveIndex(-1);
   }, [setActiveIndex]);
 
@@ -260,9 +261,9 @@ export function ManifestStatusPieChart() {
     <ResponsiveContainer minWidth={100} minHeight={300} height={'10%'}>
       <PieChart width={400} height={400}>
         <Legend
-          content={(props: any) => {
-            return renderLegend({ ...props, handleMouseEnter, handleMouseLeave, handleClick });
-          }}
+          content={(props: any) =>
+            renderLegend({ ...props, handleMouseEnter, handleMouseLeave, handleClick })
+          }
           verticalAlign="bottom"
           height={36}
         />
@@ -271,7 +272,7 @@ export function ManifestStatusPieChart() {
           onAnimationEnd={() => setAnimationIsActive(false)}
           onAnimationStart={() => setAnimationIsActive(true)}
           activeIndex={activeIndex}
-          activeShape={(props: any) => renderShape(props)}
+          activeShape={renderActiveShape}
           data={data}
           cx="50%"
           cy="50%"

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -15,8 +15,8 @@ const data: Array<Entry> = [
   { name: 'Ready for TSDF Signature', value: 21, searchParam: 'readyforsignature' },
 ];
 
-const normalAlpha = '0.6';
-const activeAlpha = '1';
+const normalAlpha = '1';
+const activeAlpha = '.75';
 
 const COLORS = [
   { normal: `rgba(0, 136, 254, ${normalAlpha})`, active: `rgba(0, 136, 254, ${activeAlpha})` },
@@ -134,7 +134,7 @@ const renderShape = (props: any, isActive: boolean) => {
 };
 
 const renderLegend = (props: any) => {
-  const { payload, handleMouseEnter, handleMouseLeave } = props;
+  const { payload, handleMouseEnter, handleMouseLeave, handleClick } = props;
 
   return (
     <div
@@ -146,18 +146,30 @@ const renderLegend = (props: any) => {
         style={{ padding: '0px', margin: '0px', textAlign: 'center' }}
       >
         {payload.map((entry: any, index: number) => {
-          const activeLegend =
-            entry.color.slice(entry.color.lastIndexOf(' ') + 1, entry.color.length - 1) === '1';
+          const dataEntry = data.find((d) => d.name === entry.value);
+          const activeAlphaColor = entry.color.slice(
+            entry.color.lastIndexOf(' ') + 1,
+            entry.color.length - 1
+          );
+          const activeLegend = activeAlphaColor === activeAlpha;
           const baseStyle = { color: entry.color, paddingBottom: '2px' };
           const spanStyle = activeLegend
             ? { ...baseStyle, borderBottom: `2px solid ${entry.color}` }
-            : { ...baseStyle };
+            : baseStyle;
+
+          // const activeLegend =
+          //   entry.color.slice(entry.color.lastIndexOf(' ') + 1, entry.color.length - 1) === activeAlpha;
+          // const baseStyle = { color: entry.color, paddingBottom: '2px' };
+          // const spanStyle = activeLegend
+          //   ? { ...baseStyle, borderBottom: `2px solid ${entry.color}` }
+          //   : { ...baseStyle };
 
           return (
-            <li
+            <button
               key={`item-${index}`}
               onMouseEnter={() => handleMouseEnter(null, index)}
               onMouseLeave={handleMouseLeave}
+              onClick={() => handleClick(dataEntry)}
               className={`recharts-legend-item legend-item-${index}`}
               style={{ display: 'inline-block', marginRight: '10px' }}
             >
@@ -180,7 +192,7 @@ const renderLegend = (props: any) => {
               <span className="recharts-legend-item-text" style={spanStyle}>
                 {entry.value}
               </span>
-            </li>
+            </button>
           );
         })}
       </ul>
@@ -214,7 +226,9 @@ export function ManifestStatusPieChart() {
     <ResponsiveContainer minWidth={100} minHeight={300} height="10%">
       <PieChart width={400} height={400}>
         <Legend
-          content={(props: any) => renderLegend({ ...props, handleMouseEnter, handleMouseLeave })}
+          content={(props: any) =>
+            renderLegend({ ...props, handleMouseEnter, handleMouseLeave, handleClick })
+          }
           verticalAlign="bottom"
           height={36}
         />

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -54,7 +54,7 @@ const calculateCoordinates = (
   };
 };
 
-const renderCustomLabel = (props: any): JSX.Element | null => {
+const renderCustomLabel = (props: any): ReactElement | null => {
   const { cx, cy, midAngle, outerRadius, value, hover, activeIndex, index } = props;
   const { sin, cos } = calculateTrig(midAngle);
   const label = calculateCoordinates(outerRadius, -MID_LABEL_DISTANCE, cx, cy, sin, cos);
@@ -83,7 +83,7 @@ const renderCustomLabel = (props: any): JSX.Element | null => {
   return activeIndex !== index ? labelElement : null;
 };
 
-const renderOuterRing = (props: any): JSX.Element => {
+const renderOuterRing = (props: any): ReactElement => {
   const { cx, cy, midAngle, outerRadius, startAngle, endAngle, fill, payload, percent } = props;
   const { sin, cos } = calculateTrig(midAngle);
 
@@ -144,7 +144,7 @@ const renderOuterRing = (props: any): JSX.Element => {
   );
 };
 
-const renderShape = (props: any): JSX.Element => {
+const renderShape = (props: any): ReactElement => {
   const { cx, cy, midAngle, innerRadius, outerRadius, startAngle, endAngle, fill, onClick } = props;
   const { sin, cos } = calculateTrig(midAngle);
   const offset = 9;

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, ReactElement } from 'react';
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Sector } from 'recharts';
+import React, { ReactElement, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Sector } from 'recharts';
 
 interface Entry {
   name: string;
@@ -39,6 +39,7 @@ const calculateTrig = (midAngle: number): { sin: number; cos: number } => ({
   sin: Math.sin(-RADIAN * midAngle),
   cos: Math.cos(-RADIAN * midAngle),
 });
+
 const calculateCoordinates = (
   radius: number,
   distance: number,
@@ -60,7 +61,7 @@ const renderCustomLabel = (props: any): JSX.Element | null => {
 
   // correct for text anchoring bottom-left on (x,y) coord
   // a positive Y value moves the element down
-  // a postiive X value moves the element right
+  // a positive X value moves the element right
   const ySign = sin < 0 ? -1 : 1;
   const dDistance = 2;
   const dx = value.toString().length * -dDistance;
@@ -228,7 +229,6 @@ const renderLegend = (props: any): ReactElement => {
 
 export function ManifestStatusPieChart() {
   const [activeIndex, setActiveIndex] = useState(-1);
-  const [chartRenderComplete, setChartRenderComplete] = useState(false);
   const navigate = useNavigate();
 
   const handleMouseEnter = useCallback(
@@ -243,9 +243,7 @@ export function ManifestStatusPieChart() {
   }, [setActiveIndex]);
 
   const renderLabel = (props: any) => {
-    if (chartRenderComplete) {
-      return renderCustomLabel({ ...props, hover: false, activeIndex: activeIndex });
-    }
+    return renderCustomLabel({ ...props, hover: false, activeIndex: activeIndex });
   };
 
   const handleClick = (entry: Entry) => () => {
@@ -254,8 +252,6 @@ export function ManifestStatusPieChart() {
       search: `?status=${entry.searchParam}`,
     });
   };
-
-  const animationDuration = chartRenderComplete ? 0 : 1000;
 
   return (
     <ResponsiveContainer minWidth={100} minHeight={300} height={'10%'}>
@@ -268,8 +264,6 @@ export function ManifestStatusPieChart() {
           height={36}
         />
         <Pie
-          animationDuration={animationDuration}
-          onAnimationEnd={() => setChartRenderComplete(true)}
           activeIndex={activeIndex}
           activeShape={(props: any) => renderShape(props, true)}
           inactiveShape={(props: any) => renderShape(props, false)}

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -153,16 +153,7 @@ const renderLegend = (props: any) => {
           );
           const activeLegend = activeAlphaColor === activeAlpha;
           const baseStyle = { color: entry.color, paddingBottom: '2px' };
-          const spanStyle = activeLegend
-            ? { ...baseStyle, borderBottom: `2px solid ${entry.color}` }
-            : baseStyle;
-
-          // const activeLegend =
-          //   entry.color.slice(entry.color.lastIndexOf(' ') + 1, entry.color.length - 1) === activeAlpha;
-          // const baseStyle = { color: entry.color, paddingBottom: '2px' };
-          // const spanStyle = activeLegend
-          //   ? { ...baseStyle, borderBottom: `2px solid ${entry.color}` }
-          //   : { ...baseStyle };
+          const spanStyle = activeLegend ? { ...baseStyle, borderBottom: `2px solid` } : baseStyle;
 
           return (
             <button

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -58,10 +58,20 @@ const renderCustomLabel = (props: any): JSX.Element | null => {
   const { sin, cos } = calculateTrig(midAngle);
   const label = calculateCoordinates(outerRadius, -MID_LABEL_DISTANCE, cx, cy, sin, cos);
 
+  // correct for text anchoring bottom-left on (x,y) coord
+  // a positive Y value moves the element down
+  // a postiive X value moves the element right
+  const ySign = sin < 0 ? -1 : 1;
+  const dDistance = 2;
+  const dx = value.toString().length * -dDistance;
+  const dy = sin > 0 ? value.toString().length * ySign * dDistance : 0;
+
   const labelElement = (
     <text
       x={hover ? label.x + 8 * cos : label.x}
       y={hover ? label.y + 8 * sin : label.y}
+      dx={dx}
+      dy={dy}
       fill="white"
       dominantBaseline="central"
     >

--- a/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
+++ b/client/src/components/Charts/ManifestStatusPieChart/ManifestStatusPieChart.tsx
@@ -258,7 +258,7 @@ export function ManifestStatusPieChart() {
   const animationDuration = chartRenderComplete ? 0 : 1000;
 
   return (
-    <ResponsiveContainer minWidth={100} minHeight={300} height="10%">
+    <ResponsiveContainer minWidth={100} minHeight={300} height={'10%'}>
       <PieChart width={400} height={400}>
         <Legend
           content={(props: any) =>


### PR DESCRIPTION
## Description
Visual and interactivity enhancement to the pie chart which can present additional information to the user and indicate the presence click events.


## Issue ticket number and link
Opened to address issue (https://github.com/USEPA/haztrak/issues/733)

## To do
The <Pie> element fires its onAnimationEnd event immediately upon rendering when React strict mode is on. The initial chart animation only works properly when strict mode is turned off. I'm looking for some assistance in solving this problem which doesn't require strict mode to be turned off to see the initial animation in development.


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
