### PR TITLE
remove org access fixture

### DIFF
--- a/server/fixtures/dev_data.yaml
+++ b/server/fixtures/dev_data.yaml
@@ -268,11 +268,6 @@
   fields:
     name: Generators Org LLC
     admin: 8062d496-15f1-485d-961c-a8e5fa118dde
-- model: org.orgaccess
-  pk: 1
-  fields:
-    org: efb9e104-7f61-4365-a9af-9d7b55c854c4
-    user: 4ac96f68-42cf-47ea-bffb-f24d423dbc35
 - model: profile.profile
   pk: c65dbee9-b6bf-400e-93e0-90a749cc2939
   fields:


### PR DESCRIPTION
## Description

title says it all. Quick fix that removes a fixture that points to a model that no longer exists.

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
