### PR TITLE
Org list view

### DIFF
--- a/server/org/fixtures/org_permissions.yaml
+++ b/server/org/fixtures/org_permissions.yaml
@@ -36,3 +36,13 @@
       - - view_siteuserobjectpermission
         - org
         - siteuserobjectpermission
+- model: org.orguserobjectpermission
+  pk: 1
+  fields:
+    permission:
+      - view_org
+      - org
+      - org
+    user:
+      - testuser1
+    content_object: efb9e104-7f61-4365-a9af-9d7b55c854c4

--- a/server/org/services.py
+++ b/server/org/services.py
@@ -57,8 +57,7 @@ def update_emanifest_sync_date(site: Site, last_sync_date: Optional[datetime] = 
 
 def filter_sites_by_org(org_slug: str) -> QuerySet[Site]:
     """Returns a list of Sites associated with an Org."""
-    sites: QuerySet = Site.objects.filter(org__slug=org_slug).select_related("rcra_site")
-    return sites
+    return Site.objects.filter(org__slug=org_slug).select_related("rcra_site")
 
 
 def get_user_site(username: str, epa_id: str) -> Site:

--- a/server/org/urls.py
+++ b/server/org/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 
-from .views import OrgDetailsView, SiteDetailsView, SiteListView
+from .views import OrgDetailsView, OrgListView, SiteDetailsView, SiteListView
 
 app_name = "org"
 
@@ -16,6 +16,7 @@ site_urls = (
 )
 
 urlpatterns = [
+    path("orgs", OrgListView.as_view(), name="list"),
     path("orgs/<slug:org_slug>", OrgDetailsView.as_view(), name="details"),
     path("orgs/<slug:org_slug>/sites", SiteListView.as_view(), name="sites"),
     path("sites", include(site_urls)),

--- a/server/org/views.py
+++ b/server/org/views.py
@@ -27,6 +27,14 @@ class OrgDetailsView(RetrieveAPIView):
         return org
 
 
+class OrgListView(ListAPIView):
+    """that returns all haztrak organization that the user has access to."""
+
+    serializer_class = OrgSerializer
+    queryset = Org.objects.all()
+    filter_backends = [ObjectPermissionsFilter]
+
+
 class SiteListView(ListAPIView):
     """that returns all haztrak sites that the user has access to."""
 


### PR DESCRIPTION
## Description

Adds a list api view for organizations and a fixture for local development that automatically adds view level permissions for the testuser and test organization. 

## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
