### PR TITLE
Rtk query avatar endpoint

### DIFF
--- a/client/app/store/htApi.slice.ts
+++ b/client/app/store/htApi.slice.ts
@@ -18,6 +18,7 @@ export interface HtApiQueryArgs {
   method: AxiosRequestConfig['method'];
   data?: AxiosRequestConfig['data'];
   params?: AxiosRequestConfig['params'];
+  headers?: AxiosRequestConfig['headers'];
 }
 
 export interface HtApiError extends AxiosError {
@@ -42,8 +43,8 @@ export const htApiBaseQuery =
     HtApiError
     // Meta
   > =>
-  async ({ url, method, data, params }) => {
-    return htApi({ url: baseUrl + url, method, data, params })
+  async ({ url, method, data, params, headers }) => {
+    return htApi({ url: baseUrl + url, method, data, params, headers })
       .then((response) => {
         return { data: response.data };
       })

--- a/client/app/store/index.ts
+++ b/client/app/store/index.ts
@@ -34,11 +34,11 @@ export const {
   useLogoutMutation,
   useGetUserQuery,
   useGetProfileQuery,
-  useUpdateProfileMutation,
   useGetRcrainfoProfileQuery,
   useUpdateUserMutation,
   useUpdateRcrainfoProfileMutation,
   useSyncRcrainfoProfileMutation,
+  useUpdateAvatarMutation,
 } = userApi;
 
 // Authentication Slice

--- a/client/app/store/userApi/userApi.ts
+++ b/client/app/store/userApi/userApi.ts
@@ -124,7 +124,7 @@ export const userApi = haztrakApi.injectEndpoints({
       }),
       invalidatesTags: ['profile'],
     }),
-    updateAvatar: build.mutation<ProfileSlice, { id: string; avatar: FormData }>({
+    updateAvatar: build.mutation<{ avatar: string }, { id: string; avatar: FormData }>({
       query: ({ id, avatar }) => ({
         url: `profile/${id}`,
         method: 'PATCH',

--- a/client/app/store/userApi/userApi.ts
+++ b/client/app/store/userApi/userApi.ts
@@ -124,6 +124,17 @@ export const userApi = haztrakApi.injectEndpoints({
       }),
       invalidatesTags: ['profile'],
     }),
+    updateAvatar: build.mutation<ProfileSlice, { id: string; avatar: FormData }>({
+      query: ({ id, avatar }) => ({
+        url: `profile/${id}`,
+        method: 'PATCH',
+        data: avatar,
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      }),
+      invalidatesTags: ['profile'],
+    }),
     // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     getProfile: build.query<ProfileSlice, void>({
       query: () => ({


### PR DESCRIPTION
## Description

implments our call to update the users avatar through an RTK query endpoint which automates the process of invalidating the user profile cache and reinitiating request in other components (e.g., the header navigation). 


## Issue ticket number and link
<!-- Bonus points for using GitHub's keywords (e.g., closes #123)-->


## Checklist
<!-- Help us by answering these questions where applicable. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
